### PR TITLE
1118064: Update options for Satellite naming

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,11 @@ SAM and Satellite 6:
     It uses rhsm configuration (usually in /etc/rhsm/rhsm.conf). The system
     needs to be registered in subscription-manager server before running
     the agent.
-Satellite 5:
+
+Satellite6:
+    It will behave in the same manner as SAM.
+
+Satellite5:
     Configuration is stored in virt-who configuration file:
     /etc/sysconfig/virt-who
 

--- a/virt-who.8
+++ b/virt-who.8
@@ -2,7 +2,7 @@
 .SH NAME
 virt-who - Agent for reporting virtual guest IDs to Subscription Asset Manager, Satellite 6, or Satellite 5.
 .SH SYNOPSIS
-virt-who [-d] [-i INTERVAL] [-b] [-o] [--sam|--satellite] [--libvirt|--vdsm|--esx|--rhevm|--hyperv]
+virt-who [-d] [-i INTERVAL] [-b] [-o] [--sam|--satellite5|--satellite6] [--libvirt|--vdsm|--esx|--rhevm|--hyperv]
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
@@ -52,8 +52,11 @@ Choose where the host/guest associations should be reported
 \fB\-\-sam\fR
 Report host/guest associations to the Subscription Asset Manager or Satellite 6 [default]
 .TP
-\fB\-\-satellite\fR
-Report host/guest associations to the Satellite 5
+\fB\-\-satellite5\fR
+Report host/guest associations to the Satellite 5 server
+.IP
+\fB\-\-satellite6\fR
+Report host/guest associations to the Satellite 6 server
 .IP
 .SS Libvirt options
 .IP
@@ -131,9 +134,9 @@ Username for connecting to Hyper\-V
 \fB\-\-hyperv\-password\fR=\fIPASSWORD\fR
 Password for connecting to Hyper\-V
 .IP
-.SS Satellite options:
+.SS Satellite 5 options:
 .IP
-Use this options with \fB\-\-satellite\fR
+Use this options with \fB\-\-satellite5\fR
 .TP
 \fB\-\-satellite-server\fR=\fISAT_SERVER
 Satellite server URL
@@ -217,7 +220,7 @@ It's only available through configuration file, see virt-who-config(5) for detai
 
 .SS SUBSCRIPTION MANAGER
 
-virt-who can report host/guest associations either to Subscription Asset Manager (SAM), Satellite 6, or Satellite 5.
+virt-who can report host/guest associations to Subscription Asset Manager (SAM), to Satellite 5, or to Satellite 6.
 .TP
 1. Subscription Asset Manager or Satellite 6
 # virt-who
@@ -227,8 +230,16 @@ virt-who can report host/guest associations either to Subscription Asset Manager
 System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to SAM is shared between subscription-manager and virt-who. This is default.
 
 .TP
+2. Satellite 6
+
+# virt-who --satellite6
+
+System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to Satellite 6 is shared between subscription-manager and virt-who.
+
+.TP
 2. Satellite 5
-# virt-who --satellite --satellite-server=SAT_SERVER --satellite-username=SAT_USERNAME --satellite-password=SAT_PASSWORD
+
+# virt-who --satellite5 --satellite-server=SAT_SERVER --satellite-username=SAT_USERNAME --satellite-password=SAT_PASSWORD
 
 This option can't be used for monitoring local guests, use rhn-virtualization-host instead.
 

--- a/virt-who.conf
+++ b/virt-who.conf
@@ -21,11 +21,15 @@ VIRTWHO_DEBUG=0
 # configuration.
 #VIRTWHO_INTERVAL=0
 
-# virt-who subscription manager backend, enable ony one option from following 2:
-# Report to Subscription Asset Manager (SAM), the Red Hat Customer Portal, or Satellite 6
-#VIRTWHO_SAM=1
-# Report to Satellite 5
-#VIRTWHO_SATELLITE=0
+# Virt-who subscription manager backend. Enable only one option from the following:
+# Report to Subscription Asset Manager (SAM) or the Red Hat Customer Portal
+# VIRTWHO_SAM=1
+# Report to Sattellite version 6
+# VIRTWHO_SATELLITE6=0
+# Report to Satellite verision 5
+# VIRTWHO_SATELLITE5=0
+# Report to Satellite [Legacy]
+# VIRTWHO_SATELLITE=0
 
 # virt-who mode, enable only one option from following 5:
 # Use libvirt to list virtual guests [default]


### PR DESCRIPTION
Added named options to config and cli for satellite 5 and 6.
satellite 6 maps to sam.
satellite 5 maps to satellite.
satellite remains a cli option but is not advertised.