### PR TITLE
Initialize for tito usage

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,0 +1,17 @@
+[fedora]
+releaser = tito.release.FedoraGitReleaser
+branches = master f21 f20
+
+[rhel-7.2]
+releaser = tito.release.DistGitReleaser
+branches = rhel-7.2
+required_bz_flags = rhel-7.2.0+
+# Change this if you wish to use a placeholder "rebase" bug if none
+# are found in the changelog.
+#placeholder_bz = 1109810
+
+#[copr-dgoodwin]
+#releaser = tito.release.CoprReleaser
+#project_name = virt-who
+#upload_command = scp %(srpm)s rm-rf.ca:/home/dgoodwin/public_html/copr/
+#remote_location = http://rm-rf.ca/~dgoodwin/copr/

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)


### PR DESCRIPTION
This PR sets everything up for use with the tito build/release tool, available in Fedora and EPEL. 

Before it can be used, once merged, you'll need to create an initial tag, presumably the 0.13 release. Just run (tito tag, and accept or modify the changelog message as you see fit)  The spec file will be adjusted automatically for you and included with the commit tag. Tag format will become "virt-who-0.13-1" (version and release included)

For all future tags, the changelog will actually be auto-generated for you.

If you prefix first line of commit messages with "BUGZILLANUMBER: Message", it will auto-generate dist-git commit messages, as well as do some bugzilla flag checking, and optionally use a placeholder "rebase" bug if no flagged commits are found. Very helpful for RHEL building.

After this tag is made you can start to use commands like "tito build --tgz" to get a tar.gz with consistent checksum, "tito build --rpm --test -i" to build and auto install a test rpm locally from latest code committed. (handy for development if you dont want loose files installed on your system)

I've added a few releasers for Fedora and 7.2. "tito release fedora" or "tito release rhel-7.2" will checkout the project with fedpkg/rhpkg, sync over your sources and latest spec file, generate a dist-git commit and attempt a build.  It may attempt to cleanup unnecessary files which might be a good thing in virt-who's case, but watch it carefully when it does it's work. You can use --dry-run to see what it'll do.

A commented out copr release is included, I may create a copr project myself just to do unofficial builds when they're requested.

Add --tag to most commands to specify any past tag when building/releasing (only tags made with tito, nothing prior to 0.13 will work)