### PR TITLE
Added configuration options for specifying per-host rhsm config

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,8 +40,14 @@ def parse_list(s):
     '''
     return reader([s]).next()
 
+# TODO: Not a huge fan of this. This whole class should be replaced by a dictionary or
+# dictionary-like class that provides a __missing__ implementation or "safe" getter.
 class Config(object):
-    def __init__(self, name, type, server=None, username=None, password=None, owner=None, env=None, rhsm_username=None, rhsm_password=None):
+    def __init__(self, name, type, server=None, username=None, password=None, owner=None, env=None,
+        rhsm_username=None, rhsm_password=None, rhsm_host = None, rhsm_ssl_port = None,
+        rhsm_prefix = None, rhsm_proxy_hostname = None, rhsm_proxy_port = None,
+        rhsm_proxy_user = None, rhsm_proxy_password = None, rhsm_insecure = None):
+
         self._name = name
         self._type = type
         if self._type not in VIRTWHO_TYPES:
@@ -56,6 +62,14 @@ class Config(object):
         self._env = env
         self._rhsm_username = rhsm_username
         self._rhsm_password = rhsm_password
+        self._rhsm_host = rhsm_host
+        self._rhsm_ssl_port = rhsm_ssl_port
+        self._rhsm_prefix = rhsm_prefix
+        self._rhsm_proxy_hostname = rhsm_proxy_hostname
+        self._rhsm_proxy_port = rhsm_proxy_port
+        self._rhsm_proxy_user = rhsm_proxy_user
+        self._rhsm_proxy_password = rhsm_proxy_password
+        self._rhsm_insecure = rhsm_insecure
 
         self.filter_host_uuids = []
         self.exclude_host_uuids = []
@@ -115,6 +129,47 @@ class Config(object):
         except NoOptionError:
             rhsm_password = None
 
+        try:
+            rhsm_host = parser.get(name, "rhsm_host")
+        except NoOptionError:
+            rhsm_host = None
+
+        try:
+            rhsm_ssl_port = parser.get(name, "rhsm_ssl_port")
+        except NoOptionError:
+            rhsm_ssl_port = None
+
+        try:
+            rhsm_prefix = parser.get(name, "rhsm_prefix")
+        except NoOptionError:
+            rhsm_prefix = None
+
+        try:
+            rhsm_proxy_hostname = parser.get(name, "rhsm_proxy_hostname")
+        except NoOptionError:
+            rhsm_proxy_hostname = None
+
+        try:
+            rhsm_proxy_port = parser.get(name, "rhsm_proxy_port")
+        except NoOptionError:
+            rhsm_proxy_port = None
+
+        try:
+            rhsm_proxy_user = parser.get(name, "rhsm_proxy_user")
+        except NoOptionError:
+            rhsm_proxy_user = None
+
+        try:
+            rhsm_proxy_password = parser.get(name, "rhsm_proxy_password")
+        except NoOptionError:
+            rhsm_proxy_password = None
+
+        try:
+            rhsm_insecure = parser.get(name, "rhsm_insecure")
+        except NoOptionError:
+            rhsm_insecure = None
+
+
         # Only attempt to get the encrypted rhsm password if we have a username:
         if rhsm_username is not None and rhsm_password is None:
             try:
@@ -123,7 +178,9 @@ class Config(object):
             except NoOptionError:
                 rhsm_password = None
 
-        config = Config(name, type, server, username, password, owner, env, rhsm_username, rhsm_password)
+        config = Config(name, type, server, username, password, owner, env, rhsm_username,
+            rhsm_password, rhsm_host, rhsm_ssl_port, rhsm_prefix, rhsm_proxy_hostname,
+            rhsm_proxy_port, rhsm_proxy_user, rhsm_proxy_password, rhsm_insecure)
 
         try:
             config.filter_host_uuids = parse_list(parser.get(name, "filter_host_uuids"))
@@ -194,6 +251,37 @@ class Config(object):
     def rhsm_password(self):
         return self._rhsm_password
 
+    @property
+    def rhsm_host(self):
+        return self._rhsm_host
+
+    @property
+    def rhsm_ssl_port(self):
+        return self._rhsm_ssl_port
+
+    @property
+    def rhsm_prefix(self):
+        return self._rhsm_prefix
+
+    @property
+    def rhsm_proxy_hostname(self):
+        return self._rhsm_proxy_hostname
+
+    @property
+    def rhsm_proxy_port(self):
+        return self._rhsm_proxy_port
+
+    @property
+    def rhsm_proxy_user(self):
+        return self._rhsm_proxy_user
+
+    @property
+    def rhsm_proxy_password(self):
+        return self._rhsm_proxy_password
+
+    @property
+    def rhsm_insecure(self):
+        return self._rhsm_insecure
 
 class ConfigManager(object):
     def __init__(self, config_dir=VIRTWHO_CONF_DIR):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,14 @@ owner=root
 env=staging
 rhsm_username=admin
 rhsm_password=password
+rhsm_host=host
+rhsm_ssl_port=1234
+rhsm_prefix=prefix
+rhsm_proxy_hostname=proxy host
+rhsm_proxy_port=4321
+rhsm_proxy_user=proxyuser
+rhsm_proxy_password=proxypass
+rhsm_insecure=1
 """)
 
         manager = ConfigManager(self.config_dir)
@@ -63,6 +71,14 @@ rhsm_password=password
         self.assertEqual(config.env, "staging")
         self.assertEqual(config.rhsm_username, 'admin')
         self.assertEqual(config.rhsm_password, 'password')
+        self.assertEqual(config.rhsm_host, 'host')
+        self.assertEqual(config.rhsm_ssl_port, '1234')
+        self.assertEqual(config.rhsm_prefix, 'prefix')
+        self.assertEqual(config.rhsm_proxy_hostname, 'proxy host')
+        self.assertEqual(config.rhsm_proxy_port, '4321')
+        self.assertEqual(config.rhsm_proxy_user, 'proxyuser')
+        self.assertEqual(config.rhsm_proxy_password, 'proxypass')
+        self.assertEqual(config.rhsm_insecure, '1')
         self.assertEqual(config.esx_simplified_vim, True)
 
     def testInvalidConfig(self):
@@ -140,16 +156,36 @@ type=esx
 server=1.2.3.4
 username=admin
 password=password
-owner=root
-env=staging
+owner=root1
+env=staging1
+rhsm_username=rhsm_admin1
+rhsm_password=rhsm_password1
+rhsm_host=host1
+rhsm_ssl_port=12341
+rhsm_prefix=prefix1
+rhsm_proxy_hostname=proxyhost1
+rhsm_proxy_port=43211
+rhsm_proxy_user=proxyuser1
+rhsm_proxy_password=proxypass1
+rhsm_insecure=1
 
 [test2]
 type=hyperv
 server=1.2.3.5
 username=admin
 password=password
-owner=root
-env=staging
+owner=root2
+env=staging2
+rhsm_username=rhsm_admin2
+rhsm_password=rhsm_password2
+rhsm_host=host2
+rhsm_ssl_port=12342
+rhsm_prefix=prefix2
+rhsm_proxy_hostname=proxyhost2
+rhsm_proxy_port=43212
+rhsm_proxy_user=proxyuser2
+rhsm_proxy_password=proxypass2
+rhsm_insecure=2
 """)
 
         manager = ConfigManager(self.config_dir)
@@ -160,16 +196,36 @@ env=staging
         self.assertEqual(config.server, "1.2.3.4")
         self.assertEqual(config.username, "admin")
         self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
+        self.assertEqual(config.owner, "root1")
+        self.assertEqual(config.env, "staging1")
+        self.assertEqual(config.rhsm_username, 'rhsm_admin1')
+        self.assertEqual(config.rhsm_password, 'rhsm_password1')
+        self.assertEqual(config.rhsm_host, 'host1')
+        self.assertEqual(config.rhsm_ssl_port, '12341')
+        self.assertEqual(config.rhsm_prefix, 'prefix1')
+        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost1')
+        self.assertEqual(config.rhsm_proxy_port, '43211')
+        self.assertEqual(config.rhsm_proxy_user, 'proxyuser1')
+        self.assertEqual(config.rhsm_proxy_password, 'proxypass1')
+        self.assertEqual(config.rhsm_insecure, '1')
         config = manager.configs[1]
         self.assertEqual(config.name, "test2")
         self.assertEqual(config.type, "hyperv")
         self.assertEqual(config.username, "admin")
         self.assertEqual(config.server, "1.2.3.5")
         self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
+        self.assertEqual(config.owner, "root2")
+        self.assertEqual(config.env, "staging2")
+        self.assertEqual(config.rhsm_username, 'rhsm_admin2')
+        self.assertEqual(config.rhsm_password, 'rhsm_password2')
+        self.assertEqual(config.rhsm_host, 'host2')
+        self.assertEqual(config.rhsm_ssl_port, '12342')
+        self.assertEqual(config.rhsm_prefix, 'prefix2')
+        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost2')
+        self.assertEqual(config.rhsm_proxy_port, '43212')
+        self.assertEqual(config.rhsm_proxy_user, 'proxyuser2')
+        self.assertEqual(config.rhsm_proxy_password, 'proxypass2')
+        self.assertEqual(config.rhsm_insecure, '2')
 
     def testMultipleConfigFiles(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -181,6 +237,16 @@ username=admin
 password=password
 owner=root
 env=staging
+rhsm_username=rhsm_admin1
+rhsm_password=rhsm_password1
+rhsm_host=host1
+rhsm_ssl_port=12341
+rhsm_prefix=prefix1
+rhsm_proxy_hostname=proxyhost1
+rhsm_proxy_port=43211
+rhsm_proxy_user=proxyuser1
+rhsm_proxy_password=proxypass1
+rhsm_insecure=1
 """)
         with open(os.path.join(self.config_dir, "test2.conf"), "w") as f:
             f.write("""
@@ -191,6 +257,16 @@ username=admin
 password=password
 owner=root
 env=staging
+rhsm_username=rhsm_admin2
+rhsm_password=rhsm_password2
+rhsm_host=host2
+rhsm_ssl_port=12342
+rhsm_prefix=prefix2
+rhsm_proxy_hostname=proxyhost2
+rhsm_proxy_port=43212
+rhsm_proxy_user=proxyuser2
+rhsm_proxy_password=proxypass2
+rhsm_insecure=2
 """)
 
         manager = ConfigManager(self.config_dir)
@@ -209,6 +285,16 @@ env=staging
         self.assertEqual(config1.password, "password")
         self.assertEqual(config1.owner, "root")
         self.assertEqual(config1.env, "staging")
+        self.assertEqual(config1.rhsm_username, 'rhsm_admin1')
+        self.assertEqual(config1.rhsm_password, 'rhsm_password1')
+        self.assertEqual(config1.rhsm_host, 'host1')
+        self.assertEqual(config1.rhsm_ssl_port, '12341')
+        self.assertEqual(config1.rhsm_prefix, 'prefix1')
+        self.assertEqual(config1.rhsm_proxy_hostname, 'proxyhost1')
+        self.assertEqual(config1.rhsm_proxy_port, '43211')
+        self.assertEqual(config1.rhsm_proxy_user, 'proxyuser1')
+        self.assertEqual(config1.rhsm_proxy_password, 'proxypass1')
+        self.assertEqual(config1.rhsm_insecure, '1')
 
         self.assertEqual(config2.name, "test2")
         self.assertEqual(config2.type, "hyperv")
@@ -217,6 +303,16 @@ env=staging
         self.assertEqual(config2.password, "password")
         self.assertEqual(config2.owner, "root")
         self.assertEqual(config2.env, "staging")
+        self.assertEqual(config2.rhsm_username, 'rhsm_admin2')
+        self.assertEqual(config2.rhsm_password, 'rhsm_password2')
+        self.assertEqual(config2.rhsm_host, 'host2')
+        self.assertEqual(config2.rhsm_ssl_port, '12342')
+        self.assertEqual(config2.rhsm_prefix, 'prefix2')
+        self.assertEqual(config2.rhsm_proxy_hostname, 'proxyhost2')
+        self.assertEqual(config2.rhsm_proxy_port, '43212')
+        self.assertEqual(config2.rhsm_proxy_user, 'proxyuser2')
+        self.assertEqual(config2.rhsm_proxy_password, 'proxypass2')
+        self.assertEqual(config2.rhsm_insecure, '2')
 
     def testLibvirtConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -163,7 +163,8 @@ class TestOptions(TestBase):
         virtwho = VirtWho(self.logger, options)
         config = Config("test", "esx", "localhost", "username", "password", "owner", "env")
         virtwho.configManager.addConfig(config)
-        virtwho.queue.put(HostGuestAssociationReport(config, {'a': ['b']}))
+        virtwho.queue.put(HostGuestAssociationReport(config, {'a1': ['b1']}))
+        virtwho.queue.put(HostGuestAssociationReport(config, {'a2': ['b2']}))
         virtwho.run()
 
         fromConfig.assert_called_with(self.logger, config)


### PR DESCRIPTION
- Hosts can now specify most, if not all, rhsm configuration options
  in their host config. The configuration follows the same format as
  the rhsm.conf, except each option is prefixed with "rhsm_".