### PR TITLE
Change Detection

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,6 +25,8 @@ from csv import reader
 from ConfigParser import SafeConfigParser, NoOptionError, Error, MissingSectionHeaderError
 from password import Password
 from binascii import unhexlify
+import hashlib
+import json
 
 VIRTWHO_CONF_DIR = "/etc/virt-who.d/"
 VIRTWHO_TYPES = ("libvirt", "vdsm", "esx", "rhevm", "hyperv", "fake")
@@ -298,6 +300,10 @@ class Config(object):
     @property
     def rhsm_insecure(self):
         return self._rhsm_insecure
+
+    @property
+    def hash(self):
+        return hashlib.md5(json.dumps(self.__dict__, sort_keys=True)).hexdigest()
 
 class ConfigManager(object):
     def __init__(self, config_dir=None):

--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -121,4 +121,3 @@ class TestLibvirtd(TestBase):
         result = queue.get(True)
         for host in result.association['hypervisors']:
             self.assertTrue(host.name is None)
-

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -214,14 +214,13 @@ class TestJobs(TestBase):
 
 
 class TestSend(TestBase):
-    def test_send_same_twice(self):
+    @patch('manager.Manager.fromOptions')
+    def test_send_same_twice(self, fromOptions):
         options = Mock()
         options.interval = 0
         options.oneshot = True
         options._print = False
         virtwho = VirtWho(self.logger, options, config_dir="/nonexistant")
-        virtwho._sendGuestList = Mock()
-        virtwho._sendGuestAssociation = Mock()
 
         config = Config('test', 'esx', 'localhost', 'username', 'password', 'owner','env')
         config2 = Config('test2', 'esx', 'localhost', 'username', 'password', 'owner', 'env')

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -47,9 +47,14 @@ class TestOptions(TestBase):
         self.assertFalse(options.debug)
         self.assertFalse(options.background)
         self.assertFalse(options.oneshot)
-        self.assertEqual(options.interval, 3600)
+        self.assertEqual(options.interval, 600)
         self.assertEqual(options.smType, 'sam')
         self.assertEqual(options.virtType, None)
+
+    def test_minimum_interval_options(self):
+        sys.argv = ["virtwho.py", "--interval=5"]
+        _, options = parseOptions()
+        self.assertEqual(options.interval, 600)
 
     def test_options_debug(self):
         sys.argv = ["virtwho.py", "-d"]

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -212,3 +212,28 @@ class TestJobs(TestBase):
         virtwho.addJob(test_job_tuple)
         virtwho.run()
         virtwho.send.assert_called_with(fake_report)
+
+
+class TestSend(TestBase):
+    def test_send_same_twice(self):
+        options = Mock()
+        options.interval = 0
+        options.oneshot = True
+        options._print = False
+        virtwho = VirtWho(self.logger, options, config_dir="/nonexistant")
+        virtwho._sendGuestList = Mock()
+        virtwho._sendGuestAssociation = Mock()
+
+        config = Config('test', 'esx', 'localhost', 'username', 'password', 'owner','env')
+        config2 = Config('test2', 'esx', 'localhost', 'username', 'password', 'owner', 'env')
+        fake_virt = Mock()
+        fake_virt.CONFIG_TYPE = 'esx'
+        test_hypervisor = Hypervisor('test', guestIds=[Guest('guest1', fake_virt, 1)])
+        assoc = {'hypervisors': [test_hypervisor]}
+        fake_report = HostGuestAssociationReport(config, assoc)
+        virtwho.configManager.addConfig(config)
+        virtwho.configManager.addConfig(config2)
+
+        self.assertTrue(virtwho.send(fake_report))
+        # if the report is the same we should not send it
+        self.assertFalse(virtwho.send(fake_report))

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -27,10 +27,8 @@ from mock import patch, Mock
 
 from virtwho import parseOptions, VirtWho, OptionError, Queue, Job
 from config import Config
-from virt import VirtError, HostGuestAssociationReport
-from manager import ManagerError
-from multiprocessing import Process
-from threading import Timer
+from virt import HostGuestAssociationReport, Hypervisor, Guest
+
 
 class TestOptions(TestBase):
     def setUp(self):
@@ -177,6 +175,7 @@ class TestOptions(TestBase):
         fromConfig.assert_called_with(self.logger, config)
         self.assertTrue(fromConfig.return_value.start.called)
         fromOptions.assert_called_with(self.logger, options)
+
 
 class TestJobs(TestBase):
     def setupVirtWho(self, oneshot=True):

--- a/virt-who.conf
+++ b/virt-who.conf
@@ -17,8 +17,8 @@ VIRTWHO_DEBUG=0
 # Send the list of guest IDs and exit immediately.
 #VIRTWHO_ONE_SHOT=0
 
-# Acquire and send list of virtual guest each N seconds, 0 means default
-# configuration.
+# Acquire list of virtual guest each N seconds, only sends if changes detected
+# 0 means default configuration.
 #VIRTWHO_INTERVAL=0
 
 # Virt-who subscription manager backend. Enable only one option from the following:

--- a/virt/esx/esx.py
+++ b/virt/esx/esx.py
@@ -68,6 +68,7 @@ class Esx(virt.Virt):
         self._prepare()
 
         version = ''
+        last_version = 'last_version'  # Bogus value so version != last_version from the start
         self.hosts = defaultdict(Host)
         self.vms = defaultdict(VM)
         start_time = end_time = time()
@@ -131,8 +132,10 @@ class Esx(virt.Virt):
             if hasattr(updateSet, 'truncated') and updateSet.truncated:
                 continue
 
-            assoc = self.getHostGuestMapping()
-            self._queue.put(virt.HostGuestAssociationReport(self.config, assoc))
+            if last_version != version:
+                assoc = self.getHostGuestMapping()
+                self._queue.put(virt.HostGuestAssociationReport(self.config, assoc))
+                last_version = version
 
             end_time = time()
 

--- a/virt/virt.py
+++ b/virt/virt.py
@@ -149,6 +149,10 @@ class DomainListReport(AbstractVirtReport):
     def guests(self):
         return self._guests
 
+    @property
+    def hash(self):
+        return hashlib.md5(json.dumps([g.toDict() for g in self.guests], sort_keys=True)).hexdigest()
+
 
 class HostGuestAssociationReport(AbstractVirtReport):
     '''
@@ -172,6 +176,14 @@ class HostGuestAssociationReport(AbstractVirtReport):
                 continue
             assoc[host] = guests
         return assoc
+
+    @property
+    def serializedAssociation(self):
+        return {'hypervisors':[h.toDict() for h in self.association['hypervisors']]}
+
+    @property
+    def hash(self):
+        return hashlib.md5(json.dumps(self.serializedAssociation, sort_keys=True)).hexdigest()
 
 
 class HypervisorInfoReport(AbstractVirtReport):

--- a/virt/virt.py
+++ b/virt/virt.py
@@ -23,6 +23,8 @@ import time
 import logging
 from datetime import datetime
 from multiprocessing import Process, Event
+import json
+import hashlib
 
 
 class VirtError(Exception):
@@ -110,6 +112,10 @@ class Hypervisor(object):
 
     def __str__(self):
         return str(self.toDict())
+
+    def getHash(self):
+        sortedRepresentation = json.dumps(self.toDict(), sort_keys=True)
+        return hashlib.md5(sortedRepresentation).hexdigest()
 
 
 class AbstractVirtReport(object):

--- a/virtwho.py
+++ b/virtwho.py
@@ -341,6 +341,7 @@ class VirtWho(object):
 
     def reload(self):
         self.logger.warn("virt-who reload")
+        self.reports = {}
         # clear the queue and put "reload" there
         try:
             while True:

--- a/virtwho.py
+++ b/virtwho.py
@@ -150,7 +150,6 @@ class VirtWho(object):
 
         return - True if sending is successful, False otherwise
         """
-        self.logger.debug('REPORTS GET: %s' % self.reports)
         if (hasattr(report, 'hash') and report.hash == self.reports.get(report.config.hash)):
             self.logger.debug('Got a duplicate report, refusing to send')
             return False

--- a/virtwho.py
+++ b/virtwho.py
@@ -278,7 +278,7 @@ class VirtWho(object):
                             # Do not send if the report hash is already in the
                             # list of reports sent
                             if hasattr(report, 'hash') and report.hash == self.reports.get(report.config.hash):
-                                self.logger.info('No changes detected, report not sent.')
+                                self.logger.info('No change in report gathered using config: "%s", report not sent.', report.config.name)
                                 break
                             if self.send(report):
                                 break


### PR DESCRIPTION
This modifies when virt-who sends reports to the following times:
- On start up: As soon as virt-who is started up, all virt backends will make an initial report which virt-who will send
- On reload: Reload causes the virt backends to be restarted, now it also clears the list of sent reports (so as to ignore any changes or lack there of)
- On receipt of a report different from the last one generated by the same virt backend: Virt-who now keeps track of the hash of the last report sent for each configured virt backend.
- In oneshot mode: No changes are tracked between runs in oneshot mode

The minimum interval to collect / send reports has been raised to 10 minutes.
Changes to the virt backends are as follows:
-libvirtd: All reports, aside from an initial report created when the process starts, are generated via the callback in response to events from libvirt
-esx: Reports are only sent when the version string changes

As of now a report is considered to have changed if its hash has changed. If the hash has changed the entire report will be sent. In future updates we might want to consider sending only what changed.