### PR TITLE
Moves fakevirt._decode() to util.decode()

### DIFF
--- a/util.py
+++ b/util.py
@@ -1,6 +1,16 @@
 
 __all__ = ('OrderedDict',)
 
+def decode(input):
+    if isinstance(input, dict):
+        return dict((decode(key), decode(value)) for key, value in input.iteritems())
+    elif isinstance(input, list):
+        return [decode(element) for element in input]
+    elif isinstance(input, unicode):
+        return input.encode('utf-8')
+    else:
+        return input
+
 # Taken from http://code.activestate.com/recipes/576693/
 
 # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.

--- a/virt/fakevirt/fakevirt.py
+++ b/virt/fakevirt/fakevirt.py
@@ -2,16 +2,8 @@
 from virt import Virt, VirtError, Guest, Hypervisor
 
 import json
+from util import decode
 
-def _decode(input):
-    if isinstance(input, dict):
-        return dict((_decode(key), _decode(value)) for key, value in input.iteritems())
-    elif isinstance(input, list):
-        return [_decode(element) for element in input]
-    elif isinstance(input, unicode):
-        return input.encode('utf-8')
-    else:
-        return input
 
 class FakeVirt(Virt):
     CONFIG_TYPE = 'fake'
@@ -25,7 +17,7 @@ class FakeVirt(Virt):
         # TODO: do some checking of the file content
         try:
             with open(self.config.fake_file, 'r') as f:
-                return json.load(f, object_hook=_decode)
+                return json.load(f, object_hook=decode)
         except (IOError, ValueError) as e:
             raise VirtError("Can't read fake '%s' virt data: %s" % (self.config.fake_file, str(e)))
 


### PR DESCRIPTION
The _decode function located inside fakevirt can be useful for general json decoding. As such I believe it should be moved to the util module.