### PR TITLE
Patch logging.FileHandler._open to prevent any actual file access

### DIFF
--- a/log.py
+++ b/log.py
@@ -49,7 +49,7 @@ class QueueHandler(logging.Handler):
     For use in logging in situations involving multiple processes
     """
     def __init__(self, queue, level=logging.NOTSET):
-        super(QueueHandler, self).__init__(level)
+        logging.Handler.__init__(self, level)
         self._queue = queue
 
     def prepare(self, record):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -40,7 +40,9 @@ class TestLog(TestBase):
 
     @patch('os.path.isdir')
     @patch('log.getDefaultQueueLogger')
-    def test_get_logger_no_config(self, getDefaultQueueLogger, isdir):
+    @patch('logging.FileHandler._open')
+    def test_get_logger_no_config(self, open, getDefaultQueueLogger, isdir):
+        open.return_value = None
         isdir.return_value = True
         queueLogger = log.QueueLogger('virtwho')
         queueLogger.logger.handlers = []
@@ -88,7 +90,9 @@ class TestLog(TestBase):
         getFileHandler.assert_called_with(test_logger.name, config.log_file, config.log_dir)
 
     @patch('os.path.isdir')
-    def test_get_file_handler_defaults(self, isdir):
+    @patch('logging.FileHandler._open')
+    def test_get_file_handler_defaults(self, open, isdir):
+        open.return_value = None  # Ensure we don't actually try to open a file
         isdir.return_value = True
         filtername = 'virtwho.test'
         fileHandler = log.getFileHandler(filtername)
@@ -98,12 +102,9 @@ class TestLog(TestBase):
 
 
     @patch('os.path.isdir')
-    def test_get_file_handler(self, isdir):
-        # Monkey patching the _open function to ensure we don't try to access a
-        # fake file
-        real_open = logging.FileHandler._open
-        logging.FileHandler._open = Mock()
-        logging.FileHandler._open.return_value = None
+    @patch('logging.FileHandler._open')
+    def test_get_file_handler(self, open, isdir):
+        open.return_value = None  # Ensure we don't actually try to open a file
 
         # Ensure we don't try to make a directory
         isdir.return_value  = True
@@ -115,8 +116,6 @@ class TestLog(TestBase):
                                          log_file,
                                          log_dir)
         self.assertTrue(fileHandler.baseFilename == log_dir + log_file)
-
-        logging.FileHandler._open = real_open
 
 
 class TestQueueLogger(TestBase):


### PR DESCRIPTION
Some of the tests (involving FileHandlers) were trying to open various files on the file system.
This patch mocks out logging.FileHandler._open for those tests which should prevent any files from actually being opened.