### PR TITLE
Fixed string interpolation issues in virt-who

### DIFF
--- a/manager/subscriptionmanager/subscriptionmanager.py
+++ b/manager/subscriptionmanager/subscriptionmanager.py
@@ -194,15 +194,15 @@ class SubscriptionManager(Manager):
                     self.logger.error("Error during update list of guests: %s", str(fail))
             for updated in resultData['updated']:
                 guests = [x['guestId'] for x in updated['guestIds']]
-                self.logger.info("Updated host %s with guests: [%s]",
+                self.logger.info("Updated host %s with guests: [%s]" % (
                                  updated['uuid'],
-                                 ", ".join(guests))
+                                 ", ".join(guests)))
             if (isinstance(result['created'], list)):
                 for created in result['created']:
                     guests = [x['guestId'] for x in created['guestIds']]
-                    self.logger.info("Created host: %s with guests: [%s]",
+                    self.logger.info("Created host: %s with guests: [%s]" % (
                                      created['uuid'],
-                                     ", ".join(guests))
+                                     ", ".join(guests)))
             self.logger.info("Number of mappings unchanged: %s" % len(resultData['unchanged']))
             result = resultData
         return result

--- a/virt/rhevm/rhevm.py
+++ b/virt/rhevm/rhevm.py
@@ -137,8 +137,8 @@ class RhevM(virt.Virt):
                 hosts[id] = virt.Hypervisor(host.find('name').text)
             else:
                 raise virt.VirtError(
-                    'Reporting of hypervisor %s is not implemented in %s backend',
-                    self.config.hypervisor_id, self.CONFIG_TYPE)
+                    'Reporting of hypervisor %s is not implemented in %s backend' %
+                    (self.config.hypervisor_id, self.CONFIG_TYPE))
             mapping[id] = []
             # BZ 1065465 Add hostname to hypervisor profile
             hosts[id].name = host.find('name').text
@@ -152,8 +152,8 @@ class RhevM(virt.Virt):
             host_id = host.get('id')
             if host_id not in mapping.keys():
                 self.logger.warning(
-                    "Guest %s claims that it belongs to host %s which doesn't exist",
-                    guest_id, host_id)
+                    "Guest %s claims that it belongs to host %s which doesn't exist" % (
+                    guest_id, host_id))
                 continue
             try:
                 state = RHEVM_STATE_TO_GUEST_STATE.get(

--- a/virt/virt.py
+++ b/virt/virt.py
@@ -330,7 +330,7 @@ class Virt(Process):
                 if self.is_terminated():
                     return
 
-                self.logger.info("Waiting %s seconds before retrying backend '%s'", self._interval, self.config.name)
+                self.logger.info("Waiting %s seconds before retrying backend '%s'" % (self._interval, self.config.name))
                 self.wait(self._interval)
         except KeyboardInterrupt:
             sys.exit(1)


### PR DESCRIPTION
* fix issues where logging was not interpolating strings right.
* verified all strings with thwo %s are now with correct interpolation in the code base
* also verified there are no strings with more than two %s