### PR TITLE
Adds hypervisor version information to guests (ESX, hyperv, libvirt)

### DIFF
--- a/virt/esx/esx.py
+++ b/virt/esx/esx.py
@@ -194,7 +194,12 @@ class Esx(virt.Virt):
                             state = virt.Guest.STATE_SHUTOFF
                     except KeyError:
                         self.logger.debug("Guest '%s' doesn't have 'runtime.powerState' property" % vm_id.value)
-                    guests.append(virt.Guest(vm['config.uuid'], self, state, hypervisorType=host.get('config.product.fullName', 'vmware')))
+                    guests.append(virt.Guest(vm['config.uuid'],
+                                             self,
+                                             state,
+                                             hypervisorType=host.get('config.product.name', 'vmware'),
+                                             hypervisorVersion=host.get('config.product.version', None)
+                                             ))
             mapping['hypervisors'].append(Hypervisor(hypervisorId=uuid, guestIds=guests, name=host.get('name', None)))
         return mapping
 
@@ -250,7 +255,7 @@ class Esx(virt.Virt):
         pfs.objectSet = [oSpec]
         pfs.propSet = [
             self.createPropertySpec("VirtualMachine", ["config.uuid", "runtime.powerState"]),
-            self.createPropertySpec("HostSystem", ["name", "vm", "hardware.systemInfo.uuid", "parent", "config.product.fullName"])
+            self.createPropertySpec("HostSystem", ["name", "vm", "hardware.systemInfo.uuid", "parent", "config.product.name", "config.product.version"])
         ]
 
         return self.client.service.CreateFilter(_this=self.sc.propertyCollector, spec=pfs, partialUpdates=0)

--- a/virt/esx/esx.py
+++ b/virt/esx/esx.py
@@ -194,7 +194,7 @@ class Esx(virt.Virt):
                             state = virt.Guest.STATE_SHUTOFF
                     except KeyError:
                         self.logger.debug("Guest '%s' doesn't have 'runtime.powerState' property" % vm_id.value)
-                    guests.append(virt.Guest(vm['config.uuid'], self, state, hypervisorType='vmware'))
+                    guests.append(virt.Guest(vm['config.uuid'], self, state, hypervisorType=host.get('config.product.fullName', 'vmware')))
             mapping['hypervisors'].append(Hypervisor(hypervisorId=uuid, guestIds=guests, name=host.get('name', None)))
         return mapping
 
@@ -250,7 +250,7 @@ class Esx(virt.Virt):
         pfs.objectSet = [oSpec]
         pfs.propSet = [
             self.createPropertySpec("VirtualMachine", ["config.uuid", "runtime.powerState"]),
-            self.createPropertySpec("HostSystem", ["name", "vm", "hardware.systemInfo.uuid", "parent"])
+            self.createPropertySpec("HostSystem", ["name", "vm", "hardware.systemInfo.uuid", "parent", "config.product.fullName"])
         ]
 
         return self.client.service.CreateFilter(_this=self.sc.propertyCollector, spec=pfs, partialUpdates=0)

--- a/virt/fakevirt/fakevirt.py
+++ b/virt/fakevirt/fakevirt.py
@@ -30,7 +30,9 @@ class FakeVirt(Virt):
         attributes = guest.get('attributes', {})
         self.CONFIG_TYPE = attributes.get('virtWhoType', 'fake')
         hypervisorType = attributes.get('hypervisorType', None)
-        return Guest(guest['guestId'], self, guest['state'], hypervisorType=hypervisorType)
+        hypervisorVersion = attributes.get('hypervisorVersion', None)
+        return Guest(guest['guestId'], self, guest['state'], hypervisorType=hypervisorType,
+                     hypervisorVersion=hypervisorVersion)
 
     def _process_hypervisor(self, hypervisor):
         guests = []

--- a/virt/hyperv/hyperv.py
+++ b/virt/hyperv/hyperv.py
@@ -439,6 +439,20 @@ class HyperV(virt.Virt):
             s = uuid
         return s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + s[18:]
 
+    def getVmmsVersion(self, hypervsoap):
+        """
+        This method retrieves the version of the vmms executable as it is the authoritative
+        version of hyper-v running on the machine.
+
+        https://social.technet.microsoft.com/Forums/windowsserver/en-US/dce2a4ec-10de-4eba-a19d-ae5213a2382d/how-to-tell-version-of-hyperv-installed?forum=winserverhyperv
+        """
+        vmmsVersion = ""
+        data = hypervsoap.Enumerate("select * from CIM_Datafile where FileName='vmms'", "root/cimv2")
+        for instance in hypervsoap.Pull(data, "root/cimv2"):
+            if (instance['Path'] == '\\windows\\system32\\'):
+                vmmsVersion = instance['Version']
+        return vmmsVersion
+
     def getHostGuestMapping(self):
         guests = []
         connection, headers = self.connect()
@@ -470,7 +484,7 @@ class HyperV(virt.Virt):
         # Get guest states
         guest_states = hypervsoap.Invoke_GetSummaryInformation(
                 "root/virtualization/v2" if self.useNewApi else "root/virtualization")
-
+        vmmsVersion = self.getVmmsVersion(hypervsoap)
         for instance in hypervsoap.Pull(uuid):
             try:
                 uuid = instance["BIOSGUID"]
@@ -495,7 +509,8 @@ class HyperV(virt.Virt):
                     HyperV.decodeWinUUID(uuid),
                     self,
                     state,
-                    hypervisorType='hyperv'))
+                    hypervisorType='hyperv',
+                    hypervisorVersion=vmmsVersion))
         # Get the hostname
         hostname = None
         data = hypervsoap.Enumerate("select DNSHostName from Win32_ComputerSystem", "root/cimv2")

--- a/virt/libvirtd/libvirtd.py
+++ b/virt/libvirtd/libvirtd.py
@@ -45,7 +45,7 @@ class LibvirtdGuest(virt.Guest):
             uuid=domain.UUIDString(),
             virt=libvirtd,
             state=state,
-            hypervisorType=libvirtd.virt.getType())
+            hypervisorType=libvirtd.getHypervisorType())
 
 
 class VirEventLoopThread(threading.Thread):
@@ -85,6 +85,28 @@ class Libvirtd(virt.Virt):
         self._host_name = None
         self.eventLoopThread = None
         libvirt.registerErrorHandler(lambda ctx, error: None, None)
+
+    def getVersion(self):
+        """
+        The constants used to extract the version numbers were found in
+        /lib64/python2.7/site-packages/libvirt.py
+        """
+        version_num = self.virt.getVersion()
+        major = version_num / 1000000
+        version_num -= major * 1000000
+
+        minor = version_num / 1000
+        version_num -= minor * 1000
+
+        release = version_num
+        return {'major': major,
+                'minor': minor,
+                'release': release}
+
+    def getHypervisorType(self):
+        hypervisor_type_info = self.getVersion()
+        hypervisor_type_info['type'] = self.virt.getType()
+        return "%(type)s %(major)s.%(minor)s.%(release)s" % hypervisor_type_info
 
     def isHypervisor(self):
         return bool(self.config.server)

--- a/virt/libvirtd/libvirtd.py
+++ b/virt/libvirtd/libvirtd.py
@@ -45,7 +45,8 @@ class LibvirtdGuest(virt.Guest):
             uuid=domain.UUIDString(),
             virt=libvirtd,
             state=state,
-            hypervisorType=libvirtd.getHypervisorType())
+            hypervisorType=libvirtd.getHypervisorType(),
+            hypervisorVersion=libvirtd.getVersion())
 
 
 class VirEventLoopThread(threading.Thread):
@@ -99,14 +100,12 @@ class Libvirtd(virt.Virt):
         version_num -= minor * 1000
 
         release = version_num
-        return {'major': major,
+        return "%(major)s.%(minor)s.%(release)s" % {'major': major,
                 'minor': minor,
                 'release': release}
 
     def getHypervisorType(self):
-        hypervisor_type_info = self.getVersion()
-        hypervisor_type_info['type'] = self.virt.getType()
-        return "%(type)s %(major)s.%(minor)s.%(release)s" % hypervisor_type_info
+        return self.virt.getType()
 
     def isHypervisor(self):
         return bool(self.config.server)

--- a/virt/virt.py
+++ b/virt/virt.py
@@ -53,7 +53,12 @@ class Guest(object):
     STATE_CRASHED = 6      # crashed
     STATE_PMSUSPENDED = 7  # suspended by guest power management
 
-    def __init__(self, uuid, virt, state, hypervisorType=None):
+    def __init__(self,
+                 uuid,
+                 virt,
+                 state,
+                 hypervisorType=None,
+                 hypervisorVersion=None):
         """
         Create new guest instance that will be sent to the subscription manager.
 
@@ -65,11 +70,18 @@ class Guest(object):
         `hypervisorType` is additional type of the virtualization, used in libvirt.
 
         `state` is a number that represents the state of the guest (stopped, running, ...)
+
+        `hypervisorVersion` is the version of the hypervisor software running on
+        the hypervisor, if available. If none is available then the value of
+        this attribute will be an empty string ""
+            - This attribute is only included in the dictionary representation
+              if the hypervisorType is not None.
         """
         self.uuid = uuid
         self.virtWhoType = virt.CONFIG_TYPE
         self.hypervisorType = hypervisorType
         self.state = state
+        self.hypervisorVersion = hypervisorVersion or ""
 
     def toDict(self):
         d = OrderedDict((
@@ -83,6 +95,9 @@ class Guest(object):
 
         if self.hypervisorType is not None:
             d['attributes']['hypervisorType'] = self.hypervisorType
+            if self.hypervisorVersion is not None or \
+               self.hypervisorVersion is not "":
+                d['attributes']['hypervisorVersion'] = self.hypervisorVersion
         return d
 
 


### PR DESCRIPTION
### Description
This adds a new field to the virt guest model, hypervisorVersion. This new field is populated with the version information of the hypervisor software running on the host.

##### Version info sources by hypervisor type
###### ESX / vCenter
The version information is retrieved per hypervisor (in case virt-who was configured to connect to a vCenter instance etc).
###### HyperV
The version number included is the version of the vmms.exe on the file system. According to (1) (and many others that I found like it), it seems this version number is the authoritative one with regards to hyperv.
##### Libvirt
The version info, as well as the hypervisorType, is supplied via a method of libvirt. The version number returned is of the following form:
`version_number = 1000000 * major_version + 1000 * minor_version + release`

##### Rhevm
At this time the version of kvm running on the host machines, while known within the backend of rhevm, is not exposed via the rest api. This means it is rather difficult to get this information at this time and as such is *not* included in this PR.




### Links
- (1): https://social.technet.microsoft.com/Forums/windowsserver/en-US/dce2a4ec-10de-4eba-a19d-ae5213a2382d/how-to-tell-version-of-hyperv-installed?forum=winserverhyperv

