### PR TITLE
fixes RHBZ#1398639 - use the defined config when submitting local guests

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -142,7 +142,7 @@ class SubscriptionManager(Manager):
         `guests` is a list of `Guest` instances (or it children).
         """
         guests = report.guests
-        self._connect()
+        self._connect(report.config)
 
         # Sort the list
         guests.sort(key=lambda item: item.uuid)


### PR DESCRIPTION
hypervisorCheckIn was already using config.report, but sendVirtGuests
was not, which resulted in rhsm_* settings not honoured when submitting
local guests nstead of those of remote hypervisors