### PR TITLE
Add config directives to allow filtering hosts according to regex not just string matches

### DIFF
--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -122,6 +122,12 @@ Only hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is s
 \fBexclude_hosts\fR
 Hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is specified in comma-separated list in this option will \fBNOT\fR be reported. Put the value into the double-quotes if it contains special characters (like comma). \fBexclude_host_uuids\fR is deprecated alias for this option.
 .TP
+\fBfilter_hosts_regex\fR
+This option acts like filter_hosts, except it takes a comma seperated list of regular expressions of hosts to include.
+.TP
++\fBexclude_hosts_regex\fR
+This option acts like exclude_hosts, except it takes a comma seperated list of regular expressions of hosts to exclude.
+.TP
 \fBhypervisor_id\fR
 Property that should be used as identification of the hypervisor. Can be one of following: \fBuuid\fR, \fBhostname\fR, \fBhwuuid\fR. Note that some virtualization backends don't have all of them implemented. Default is \fBuuid\fR. \fBhwuuid\fR is applicable to esx and rhevm only. This property is meant to be set up before initial run of virt-who. Changing it later will result in duplicated entries in the subscription manager.
 

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -213,8 +213,10 @@ class Config(GeneralConfig):
     }
     LIST_OPTIONS = (
         'filter_hosts',
+        'filter_hosts_regex',
         'filter_host_uuids',
         'exclude_hosts',
+        'exclude_hosts_regex',
         'exclude_host_uuids',
         'filter_host_parents'
         'exclude_host_parents',

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -27,6 +27,7 @@ from multiprocessing import Process, Event
 import json
 import hashlib
 import signal
+import re
 
 try:
     from collections import OrderedDict
@@ -218,6 +219,14 @@ class HostGuestAssociationReport(AbstractVirtReport):
     def __repr__(self):
         return 'HostGuestAssociationReport({0.config!r}, {0._assoc!r}, {0.state!r})'.format(self)
 
+    def _filter(self,host,filterlist):
+        for i in filterlist:
+            if re.search(i,host):
+                # match is found
+                return 0
+        # no match
+        return 1
+
     @property
     def association(self):
         # Apply filter
@@ -231,6 +240,15 @@ class HostGuestAssociationReport(AbstractVirtReport):
             if self._config.filter_hosts is not None and host.hypervisorId not in self._config.filter_hosts:
                 logger.debug("Skipping host '%s' because its uuid is not included", host.hypervisorId)
                 continue
+
+            if self._config.exclude_hosts_regex is not None and self._filter(host.hypervisorId,self._config.exclude_hosts_regex) == 0:
+                logger.debug("Skipping host '%s' because its uuid is excluded by regex", host.hypervisorId)
+                continue 
+
+            if self._config.filter_hosts_regex is not None and self._filter(host.hypervisorId,self._config.filter_hosts_regex) != 0:
+                logger.debug("Skipping host '%s' because its uuid is excluded by regex", host.hypervisorId)
+                continue 
+
             assoc.append(host)
         return {'hypervisors': assoc}
 


### PR DESCRIPTION
I have a customer with a single vcentre infrastructure manageing a large number of esx servers. They restrict the guests by esx to linux on hosts names esxlin*, windows on esxwin* and vdi on esxvdi.  Because of this their exclude_hosts list is now approximately 40 hosts long, which is unmanageable. 

This patch introduces a new config directive exclude_hosts_regex that acts exactly like exclude_hosts but instead takes comma separated list of (python) regular expression to allow users to filter automatically in a neater and more manageable fashion. i.e. exclude_hosts_regex="esxwin.*","esxvdi.*"