### PR TITLE
Move from using processes to threads

### DIFF
--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -21,7 +21,8 @@ import os
 import requests
 import suds
 from mock import patch, ANY, MagicMock, Mock
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from virtwho.config import Config

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -20,7 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
 from mock import patch, MagicMock, ANY
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 import requests
 
 from base import TestBase

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """
 from mock import patch, Mock, sentinel
 import threading
-from multiprocessing import Queue
+from Queue import Queue
 
 from base import TestBase
 
@@ -128,7 +128,7 @@ class TestLog(TestBase):
 
 class TestQueueLogger(TestBase):
 
-    @patch('multiprocessing.queues.Queue')
+    @patch('virtwho.log.Queue')
     @patch('logging.getLogger')
     def test_queue_logger(self, getLogger, queue):
         fake_queue = sentinel.queue

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -21,7 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import os
 import requests
 from mock import patch, call, ANY, MagicMock
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from proxy import Proxy

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -20,8 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import sys
 import os
-from Queue import Empty
-from multiprocessing import Queue
+from Queue import Empty, Queue
 from mock import patch, Mock, sentinel, ANY, call
 
 from base import TestBase
@@ -463,7 +462,7 @@ class TestReload(TestBase):
     def assertStartStop(self, fromConfig):
         ''' Make sure that Virt was started and stopped. '''
         self.assertTrue(fromConfig.return_value.start.called)
-        self.assertTrue(fromConfig.return_value.terminate.called)
+        self.assertTrue(fromConfig.return_value.stop.called)
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.virt.Virt.fromConfig')

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -21,7 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import os
 import urllib2
 from mock import patch, call, ANY
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from proxy import Proxy

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -1,6 +1,6 @@
 import time
-from multiprocessing import Event, Queue
-from Queue import Empty
+from threading import Event
+from Queue import Empty, Queue
 import errno
 import socket
 
@@ -300,7 +300,6 @@ class Executor(object):
     def stop_virts(self):
         for virt in self.virts:
             virt.stop()
-            virt.terminate()
             virt.join()
         self.virts = []
 

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -26,8 +26,7 @@ import cStringIO
 import os
 import sys
 import json
-from Queue import Empty
-from multiprocessing import Queue
+from Queue import Empty, Queue
 from threading import Thread
 
 from virtwho import util

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -249,7 +249,7 @@ def exit(code, status=None):
         except KeyboardInterrupt:
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             for v in executor.virts:
-                v.terminate()
+                v.stop()
                 v.join()
     if log.hasQueueLogger():
         queueLogger = log.getQueueLogger()


### PR DESCRIPTION
This is step 1 of the interval design.
As virt-who does not need to take advantage of multiple physical cores,
we have decided to move from using processes to threads.
We consider it more maintainable and reliable to get threads to stop
than processes.

Update tests to use threading where necessary

Fix patching to refer to the right Queue class

Update assertions to ensure the proper termination method is called