### PR TITLE
Step 2 of the interval design: Implement a threadsafe datastore

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,0 +1,140 @@
+from base import TestBase
+from mock import sentinel, patch, MagicMock
+from threading import Lock
+from virtwho.datastore import Datastore
+
+
+class TestDatastore(TestBase):
+
+    def setUp(self):
+        pickle_patcher = patch('virtwho.datastore.pickle')
+        self.mock_pickle = pickle_patcher.start()
+        self.mock_pickle.dumps.return_value = sentinel.pickled_value
+        self.mock_pickle.loads.return_value = sentinel.unpickled_value
+        self.addCleanup(pickle_patcher.stop)
+
+        lock_patcher = patch('virtwho.datastore.Lock')
+        mock_lock_class = lock_patcher.start()
+        mock_lock_instance = MagicMock(spec=Lock())
+        mock_lock_class.return_value = mock_lock_instance
+        self.mock_lock = mock_lock_instance
+        self.addCleanup(lock_patcher.stop)
+
+    def mock_test_data(self, datastore, **kwargs):
+        # Sets the datastore to contain the keys and values of the kwargs
+        # in a way that does not use the put method of the datastore
+        # Returns the datastore instance as modified, the test internal
+        # datastore
+        mock_internal_datastore = MagicMock(wraps=dict(kwargs))
+        datastore._datastore = mock_internal_datastore
+        return datastore, mock_internal_datastore
+
+    def test_get_uses_lock(self):
+        # Ensure a lock is acquired before returning a particular entry in the
+        # store
+
+        # Ensure that a lock is acquired before updating a particular entry
+        # in the store.
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+                                                                 test_item=sentinel.test_value)
+
+        def assert_internal_store_unchanged(*args, **kwargs):
+            # Assert there have been no accesses of the internal datastore
+            mock_internal_datastore.__getitem__.assert_not_called()
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        def assert_internal_store_accessed(*args, **kwargs):
+            mock_internal_datastore.__getitem__.assert_called_once_with(
+                    "test_item")
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        self.mock_lock.__enter__.side_effect = assert_internal_store_unchanged
+        self.mock_lock.__exit__.side_effect = assert_internal_store_accessed
+
+        datastore.get("test_item")
+
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        self.mock_lock.__enter__.assert_called_once()
+        self.mock_lock.__exit__.assert_called_once()
+
+    def test_get_nonexistant_item_raises_keyerror(self):
+        datastore = Datastore()
+        item = sentinel.no_value
+        try:
+            item = datastore.get("NONEXISTANT")
+        except KeyError:
+            return
+        self.fail("Item retrieved for nonexistant key: %s" % item)
+
+    def test_get_nonexistant_item_with_default_returns_default(self):
+        # Ensures the default is returned if there is one provided and the
+        # key does not exist
+        datastore = Datastore()
+        result = datastore.get("NONEXISTANT", default=sentinel.default_value)
+        self.assertTrue(result == sentinel.default_value)
+
+    def test_get_existing_item_with_default_returns_item(self):
+        # Ensures the item is returned if there is a default provided,
+        # and the item exists
+        datastore = Datastore()
+        expected_value = sentinel.test_value
+        self.mock_pickle.loads.side_effect = lambda x: x
+        with patch.dict(datastore._datastore, test_item=expected_value):
+            result = datastore.get("test_item", default=sentinel.default_value)
+            self.assertEquals(result, expected_value)
+
+    def test_get_returns_correct_item(self):
+        # Ensure that calling the get method returns the right value for a
+        # particular key, and that the value is loaded using pickle
+
+        datastore = Datastore()
+        with patch.dict(datastore._datastore,
+                        test_item=sentinel.test_item_value):
+            result = datastore.get("test_item")
+        self.mock_pickle.loads.assert_called_with(sentinel.test_item_value)
+        self.assertEquals(result, self.mock_pickle.loads.return_value)
+
+    def test_put_locking(self):
+        # Ensure that a lock is acquired before (and released after) updating a
+        # particular entry in the store.
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+                                                                 test_item=sentinel.test_value)
+
+        def assert_internal_store_unchanged(*args, **kwargs):
+            # Assert there have been no accesses of the internal datastore
+            mock_internal_datastore.__getitem__.assert_not_called()
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        def assert_internal_store_accessed(*args, **kwargs):
+            mock_internal_datastore.__setitem__.assert_called_once_with(
+                    "test_item", self.mock_pickle.dumps.return_value)
+
+        self.mock_lock.__enter__.side_effect = assert_internal_store_unchanged
+        self.mock_lock.__exit__.side_effect = assert_internal_store_accessed
+
+        datastore.put("test_item", "test_item")
+        self.mock_lock.__enter__.assert_called_once()
+        self.mock_lock.__exit__.assert_called_once()
+
+    def test_put_uses_pickle_dumps(self):
+        # Ensure that put uses the return value of pickle.dumps
+        test_item = "test_value"
+        test_key = "test_item"
+        datastore, mock_internal_ds = self.mock_test_data(Datastore(),
+                                                          test_item=test_item)
+        datastore.put(test_key, test_item)
+        self.mock_pickle.dumps.assert_called_with(test_item)
+        expected_value = self.mock_pickle.dumps.return_value
+        mock_internal_ds.__setitem__.assert_called_with(test_key,
+                                                        expected_value)

--- a/virtwho/datastore.py
+++ b/virtwho/datastore.py
@@ -1,0 +1,69 @@
+"""
+Module for reading configuration files
+
+Copyright (C) 2017 Christopher Snyder <csnyder@redhat.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+from threading import Lock
+
+
+class Datastore(object):
+    """ This class is a threadsafe datastore"""
+
+    def __init__(self, *args, **kwargs):
+        self._datastore = dict()
+        self._datastore_lock = Lock()
+
+    def put(self, key, value):
+        """
+        Stores the value, retrievable by key, in a threadsafe manner in the
+        underlying datastore. (Assumes all items are pickleable)
+
+        @param key: The unique identifier for this value
+        @type  key: str
+
+        @param value: The object to store
+        """
+        with self._datastore_lock:
+            to_store = pickle.dumps(value)
+            self._datastore[key] = to_store
+
+    def get(self, key, default=None):
+        """
+        Retrieves the value for the given key, in a threadsafe manner from the
+        underlying datastore. (Assumes all items in the datastore are pickled)
+
+        @param key: The unique identifier for this value
+        @type  key: str
+
+        @param default: An optional default object to return should the
+        underlying datastore not have an item for the given key.
+
+        @raises KeyError: A KeyError is raised when the underlying datastore
+        has no item for the given key and a default has not been provided.
+        """
+        with self._datastore_lock:
+            try:
+                item = pickle.loads(self._datastore[key])
+                return item
+            except KeyError:
+                if default:
+                    return default
+                raise


### PR DESCRIPTION
This is the implementation of step 2 of the interval design.

This step depends on all prior steps.

This PR adds a threadsafe datastore into the virt-who codebase. The datastore (as of this PR) is not in use in virt-who, it is to be used in subsequent steps of the design. More specifically, this datastore will be used to allow "destination" threads to consume reports produced by one or more "source" threads.

Related trello card: https://trello.com/c/HvuaQygd/275-interval-design-step-2-create-datastore
Design doc for the overall design: https://docs.google.com/document/d/1AV-eEp1HeemTHIiigGsUBDFK3W1XWMC1flSt9jrxek4/edit