### PR TITLE
Implement the Destination Thread and friends

### DIFF
--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -35,12 +35,14 @@ class TestEsx(TestBase):
     def setUp(self):
         config = Config('test', 'esx', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.esx = Esx(self.logger, config)
+        self.esx = Esx(self.logger, config, None)  #  No dest given here
 
     def run_once(self, queue=None):
         ''' Run ESX in oneshot mode '''
         self.esx._oneshot = True
-        self.esx._queue = queue or Queue()
+        if queue is None:
+            queue = Mock(spec=Queue())
+        self.esx.dest = queue
         self.esx._terminate_event = Event()
         self.esx._oneshot = True
         self.esx._interval = 0

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -91,7 +91,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         mapping = virt.getHostGuestMapping()
         self.assertTrue("hypervisors" in mapping)
@@ -119,7 +119,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         self.assertRaises(VirtError, virt.getHostGuestMapping)
 
@@ -137,7 +137,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         guests = virt.listDomains()
         self.assertEquals(len(guests), 1)
@@ -159,6 +159,6 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         self.assertRaises(VirtError, virt.listDomains)

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -138,12 +138,12 @@ class TestHyperV(TestBase):
     def setUp(self):
         config = Config('test', 'hyperv', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.hyperv = HyperV(self.logger, config)
+        self.hyperv = HyperV(self.logger, config, None)
 
     def run_once(self, queue=None):
         ''' Run Hyper-V in oneshot mode '''
         self.hyperv._oneshot = True
-        self.hyperv._queue = queue or Queue()
+        self.hyperv.dest = queue or Queue()
         self.hyperv._terminate_event = Event()
         self.hyperv._interval = 0
         self.hyperv._run()

--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -41,8 +41,7 @@ class TestLibvirtd(TestBase):
         pass
 
     def run_virt(self, config, in_queue=None):
-        v = Virt.fromConfig(self.logger, config)
-        v._queue = in_queue or Queue()
+        v = Virt.from_config(self.logger, config, in_queue or Queue())
         v._terminate_event = Event()
         v._interval = 3600
         v._oneshot = True

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -93,12 +93,12 @@ class TestRhevM(TestBase):
     def setUp(self):
         config = Config('test', 'rhevm', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.rhevm = RhevM(self.logger, config)
+        self.rhevm = RhevM(self.logger, config, None)
 
     def run_once(self, queue=None):
         ''' Run RHEV-M in oneshot mode '''
         self.rhevm._oneshot = True
-        self.rhevm._queue = queue or Queue()
+        self.rhevm.dest = queue or Queue()
         self.rhevm._terminate_event = Event()
         self.rhevm._oneshot = True
         self.rhevm._interval = 0

--- a/tests/test_vdsm.py
+++ b/tests/test_vdsm.py
@@ -33,7 +33,7 @@ class TestVdsm(TestBase):
         def fakeSecureConnect(self):
             return MagicMock()
         Vdsm._secureConnect = fakeSecureConnect
-        self.vdsm = Vdsm(self.logger, config)
+        self.vdsm = Vdsm(self.logger, config, None)
         self.vdsm.prepare()
 
     def test_connect(self):

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -5,8 +5,13 @@ import shutil
 
 from base import TestBase
 
-from virtwho.config import ConfigManager
-from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest
+from mock import Mock, patch, call
+from threading import Event
+
+from virtwho.config import ConfigManager, Config
+from virtwho.manager import ManagerThrottleError
+from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
+    DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
 
 
 xvirt = type("", (), {'CONFIG_TYPE': 'xxx'})()
@@ -83,3 +88,354 @@ env=env
                 included_hypervisor
             ]
         }
+
+
+class TestDestinationThread(TestBase):
+    def test_get_data(self):
+        # Show that get_data accesses the given source and tries to retrieve
+        # the right source_keys
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        result_data = destination_thread._get_data()
+        self.assertEquals(result_data, datastore)
+
+    def test_get_data_ignore_same_reports(self):
+        # Show that the data returned from _get_data does not include those
+        # reports whose hash is identical to that of the last one sent for
+        # the given source
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        last_report_for_source = {
+            'source1': report1.hash
+        }
+        expected_data = {
+            'source2': report2
+        }
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.last_report_for_source = last_report_for_source
+        result_data = destination_thread._get_data()
+        self.assertEquals(result_data, expected_data)
+
+    @patch('virtwho.virt.virt.Event')
+    def test_send_data_quit_on_error_report(self, mock_event_class):
+        mock_event = Mock(spec=Event())
+        mock_event_class.return_value = mock_event
+
+        mock_error_report = Mock(spec=ErrorReport)
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread._send_data(mock_error_report)
+        mock_event.set.assert_called()
+
+    def test_send_data_batch_hypervisor_checkin(self):
+        # This tests that reports of the right type are batched into one
+        # and that the hypervisorCheckIn method of the destination is called
+        # with the right parameters
+        config1 = Config('source1', 'esx')
+        config1.exclude_hosts = []
+        config1.filter_hosts = []
+
+        config2 = Config('source2', 'esx')
+        config2.exclude_hosts = []
+        config2.filter_hosts = []
+
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+
+        def check_hypervisorCheckIn(report, options=None):
+            self.assertEquals(report.association['hypervisors'],
+                              data_to_send.values)
+
+        manager.hypervisorCheckIn = Mock(side_effect=check_hypervisorCheckIn)
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread._send_data(data_to_send)
+
+    def test_send_data_poll_hypervisor_async_result(self):
+        # This test's that when we have an async result from the server,
+        # we poll for the result
+
+        # Setup the test data
+        config1 = Config('source1', 'esx')
+        config2 = Config('source2', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+        source_keys = ['source1', 'source2']
+        batch_report1 = Mock()  # The "report" to return from hypervisorCheckIn
+        batch_report1.state = AbstractVirtReport.STATE_CREATED
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        manager.hypervisorCheckIn.return_value = batch_report1
+
+        # A closure to allow us to have a function that "modifies" the given
+        # report in a predictable way.
+        # In this case I want to set the state of the report to STATE_FINISHED
+        # after the first try
+        def check_report_state_closure():
+            # The local variables we'd like to use to keep track of state
+            # must be in a dict (or some other mutable container) as all
+            # references in the enclosing scope in python 2.X are read-only
+            local_variables = {'count': 0}
+
+            def mock_check_report_state(report):
+                if local_variables['count'] > 0:
+                    report.state = AbstractVirtReport.STATE_FINISHED
+                else:
+                    report.state = AbstractVirtReport.STATE_CREATED
+                    local_variables['count'] += 1
+                return report
+            return mock_check_report_state
+        check_report_mock = check_report_state_closure()
+        manager.check_report_state = Mock(side_effect=check_report_mock)
+        logger = Mock()
+        config = Mock()
+        config.polling_interval = 10
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        # In this test we want to see that the wait method is called when we
+        # expect and with what parameters we expect
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        # We expect there two be two calls to wait with the value of the
+        # polling_interval attr because we'd like to wait one polling
+        # interval before making the first check. Because the mock
+        # check_report_state function will modify the report to be in the
+        # successful state after the first call, we expect to wait exactly
+        # twice, both of duration config.polling_interval
+        destination_thread.wait.assert_has_calls([call(wait_time=config.polling_interval),
+                                                 call(wait_time=config.polling_interval)])
+
+    def test_send_data_poll_async_429(self):
+        # This test's that when a 429 is detected during async polling
+        # we wait for the amount of time specified
+        source_keys = ['source1', 'source2']
+        config1 = Config('source1', 'esx')
+        config2 = Config('source2', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        datastore = {'source1': report1, 'source2': report2}
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+        config = Mock()
+        config.polling_interval = 10
+        error_to_throw = ManagerThrottleError(retry_after=20)
+
+        manager = Mock()
+        manager.hypervisorCheckIn.return_value = report1
+        # A closure to allow us to have a function that "modifies" the given
+        # report in a predictable way.
+        # In this case I want to set the state of the report to STATE_FINISHED
+        # after the first try
+
+        def check_report_state_closure(items):
+            item_iterator = iter(items)
+
+            def mock_check_report_state(report):
+                item = next(item_iterator)
+                if isinstance(item, Exception):
+                    raise item
+                report.state = item
+                return report
+            return mock_check_report_state
+        states = [error_to_throw, AbstractVirtReport.STATE_FINISHED]
+        expected_wait_calls = [call(wait_time=config.polling_interval),
+                               call(wait_time=error_to_throw.retry_after)]
+
+        check_report_mock = check_report_state_closure(states)
+        manager.check_report_state = Mock(side_effect=check_report_mock)
+        logger = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        destination_thread.wait.assert_has_calls(expected_wait_calls)
+
+    def test_send_data_domain_list_reports(self):
+        # Show that DomainListReports are sent using the sendVirtGuests
+        # method of the destination
+
+        source_keys = ['source1']
+        config1 = Config('source1', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        report1 = DomainListReport(config1, [guest1],
+                                   hypervisor_id='hypervisor_id_1')
+
+        datastore = {'source1': report1}
+        data_to_send = {'source1': report1}
+
+        config = Mock()
+        config.polling_interval = 10
+        logger = Mock()
+
+        manager = Mock()
+        terminate_event = Mock()
+        interval = 10
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        manager.sendVirtGuests.assert_has_calls([call(report1,
+                                                      options=destination_thread.options)])
+
+    def test_send_data_429_during_send_virt_guests(self):
+        # Show that when a 429 is encountered during the sending of a
+        # DomainListReport that we retry after waiting the appropriate
+        # amount of time
+        source_keys = ['source1']
+        config1 = Config('source1', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        report1 = DomainListReport(config1, [guest1],
+                                   hypervisor_id='hypervisor_id_1')
+
+        datastore = {'source1': report1}
+        data_to_send = {'source1': report1}
+
+        config = Mock()
+        config.polling_interval = 10
+        logger = Mock()
+
+        error_to_throw = ManagerThrottleError(retry_after=21)
+
+        manager = Mock()
+        manager.sendVirtGuests = Mock(side_effect=[error_to_throw, report1])
+        terminate_event = Mock()
+        interval = 10
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        manager.sendVirtGuests.assert_has_calls([call(report1,
+                                                      options=destination_thread.options),
+                                                 call(report1,
+                                                      options=destination_thread.options)])
+        destination_thread.wait.assert_has_calls([call(
+                wait_time=error_to_throw.retry_after)])

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -37,12 +37,12 @@ class TestXen(TestBase):
     def setUp(self):
         config = Config('test', 'xen', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.xen = Xen(self.logger, config)
+        self.xen = Xen(self.logger, config, None)
 
     def run_once(self, queue=None):
         ''' Run XEN in oneshot mode '''
         self.xen._oneshot = True
-        self.xen._queue = queue or Queue()
+        self.xen.dest = queue or Queue()
         self.xen._terminate_event = Event()
         self.xen._oneshot = True
         self.xen._interval = 0

--- a/virtwho/virt/__init__.py
+++ b/virtwho/virt/__init__.py
@@ -2,8 +2,8 @@
 
 from virt import (Virt, VirtError, Guest, AbstractVirtReport, DomainListReport,
                   HostGuestAssociationReport, ErrorReport,
-                  Hypervisor)
+                  Hypervisor, DestinationThread)
 
 __all__ = ['Virt', 'VirtError', 'Guest', 'AbstractVirtReport',
            'DomainListReport', 'HostGuestAssociationReport',
-           'ErrorReport', 'Hypervisor']
+           'ErrorReport', 'Hypervisor', 'DestinationThread']

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -109,8 +109,12 @@ class Esx(virt.Virt):
     CONFIG_TYPE = "esx"
     MAX_WAIT_TIME = 300  # 5 minutes
 
-    def __init__(self, logger, config):
-        super(Esx, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Esx, self).__init__(logger, config, dest,
+                                  terminate_event=terminate_event,
+                                  interval=interval,
+                                  oneshot=oneshot)
         self.url = config.server
         self.username = config.username
         self.password = config.password
@@ -212,8 +216,8 @@ class Esx(virt.Virt):
 
             if last_version != version or time() > next_update:
                 assoc = self.getHostGuestMapping()
-                self.enqueue(virt.HostGuestAssociationReport(self.config, assoc))
-                next_update = time() + self._interval
+                self._send_data(virt.HostGuestAssociationReport(self.config, assoc))
+                next_update = time() + self.interval
                 last_version = version
 
             if self._oneshot:

--- a/virtwho/virt/fakevirt/fakevirt.py
+++ b/virtwho/virt/fakevirt/fakevirt.py
@@ -8,8 +8,12 @@ from virtwho.util import decode
 class FakeVirt(Virt):
     CONFIG_TYPE = 'fake'
 
-    def __init__(self, logger, config):
-        super(FakeVirt, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(FakeVirt, self).__init__(logger, config, dest,
+                                       terminate_event=terminate_event,
+                                       interval=interval,
+                                       oneshot=oneshot)
         self.logger = logger
         self.config = config
 

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -442,8 +442,12 @@ class HyperVCallFailed(HyperVException):
 class HyperV(virt.Virt):
     CONFIG_TYPE = "hyperv"
 
-    def __init__(self, logger, config):
-        super(HyperV, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(HyperV, self).__init__(logger, config, dest,
+                                     terminate_event=terminate_event,
+                                     interval=interval,
+                                     oneshot=oneshot)
         url = config.server
         self.username = config.username
         self.password = config.password

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -53,8 +53,12 @@ RHEVM_STATE_TO_GUEST_STATE = {
 class RhevM(virt.Virt):
     CONFIG_TYPE = "rhevm"
 
-    def __init__(self, logger, config):
-        super(RhevM, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(RhevM, self).__init__(logger, config, dest,
+                                    terminate_event=terminate_event,
+                                    interval=interval,
+                                    oneshot=oneshot)
         self.url = self.config.server
         if "//" not in self.url:
             self.url = "//" + self.config.server

--- a/virtwho/virt/vdsm/vdsm.py
+++ b/virtwho/virt/vdsm/vdsm.py
@@ -51,8 +51,12 @@ VDSM_STATE_TO_GUEST_STATE = {
 class Vdsm(Virt):
     CONFIG_TYPE = "vdsm"
 
-    def __init__(self, logger, config):
-        super(Vdsm, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Vdsm, self).__init__(logger, config, dest,
+                                   terminate_event=terminate_event,
+                                   interval=interval,
+                                   oneshot=oneshot)
         self._readConfig("/etc/vdsm/vdsm.conf")
 
     def isHypervisor(self):

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -28,6 +28,7 @@ import json
 import hashlib
 import re
 import fnmatch
+from virtwho.manager import ManagerError, ManagerThrottleError
 
 try:
     from collections import OrderedDict
@@ -262,29 +263,349 @@ class HostGuestAssociationReport(AbstractVirtReport):
         return hashlib.sha256(json.dumps(self.serializedAssociation, sort_keys=True)).hexdigest()
 
 
-class Virt(Thread):
-    '''
+class IntervalThread(Thread):
+    def __init__(self, logger, config, source=None, dest=None,
+                 terminate_event=None, interval=None, oneshot=False):
+        self.logger = logger
+        self.config = config
+        self.source = source
+        self.dest = dest
+        self._internal_terminate_event = Event()
+        self.terminate_event = terminate_event or self._internal_terminate_event
+        self.interval = interval or DefaultInterval
+        self._oneshot = oneshot
+        super(IntervalThread, self).__init__()
+        self.daemon = True
+
+    def wait(self, wait_time):
+        '''
+        Wait `wait_time` seconds, could be interrupted by setting _terminate_event or _internal_terminate_event.
+        '''
+        for i in range(wait_time):
+            if self.is_terminated():
+                break
+            time.sleep(1)
+
+    def is_terminated(self):
+        """
+
+        @return: Returns true if either the internal terminate event is set or
+                 the terminate event given in the init is set
+        """
+        return self._internal_terminate_event.is_set() or \
+            self.terminate_event.is_set()
+
+    def stop(self):
+        """
+        Causes this thread to stop at the next idle moment
+        """
+        self._internal_terminate_event.set()
+
+    def _run(self):
+        """
+        This method could be reimplemented in subclass to provide
+        it's own way of waiting for changes (like event monitoring)
+        """
+        self.prepare()
+        while not self.is_terminated():
+            start_time = datetime.now()
+            data_to_send = self._get_data()
+            self._send_data(data_to_send)
+            if self._oneshot:
+                break
+            end_time = datetime.now()
+
+            delta = end_time - start_time
+            # for python2.6, 2.7 has total_seconds method
+            delta_seconds = ((
+                             delta.days * 86400 + delta.seconds) * 10 ** 6 +
+                             delta.microseconds) / 10 ** 6
+
+            wait_time = self.interval - int(delta_seconds)
+
+            if wait_time < 0:
+                self.logger.debug(
+                    "Getting the data took longer than the configured "
+                    "interval. Trying again immediately.")
+                continue
+
+            self.wait(wait_time)
+
+    def _get_data(self):
+        """
+        This method gathers data from the source provided to the thread
+        @return: The data from the source
+        """
+        raise NotImplementedError("Should be implemented in subclasses")
+
+    def _send_data(self, data_to_send):
+        """
+        @param data_to_send: The data to be given to the dest
+        """
+        raise NotImplementedError("Should be implemented in subclasses")
+
+    def run(self):
+        '''
+        Wrapper around `_run` method that just catches the error messages.
+        '''
+        self.logger.debug("Thread '%s' started", self.config.name)
+        try:
+            while not self.is_terminated():
+                has_error = False
+                try:
+                    self._run()
+                except VirtError as e:
+                    if not self.is_terminated():
+                        self.logger.error("Thread '%s' fails with error: %s",
+                                          self.config.name, str(e))
+                        has_error = True
+                except Exception:
+                    if not self.is_terminated():
+                        self.logger.exception("Thread '%s' fails with "
+                                              "exception:", self.config.name)
+                        has_error = True
+
+                if self._oneshot:
+                    if has_error:
+                        self._send_data(ErrorReport(self.config))
+                    self.logger.debug("Thread '%s' stopped after sending one "
+                                      "report", self.config.name)
+                    return
+
+                if self.is_terminated():
+                    self.logger.debug("Thread '%s' terminated",
+                                      self.config.name)
+                    return
+
+                self.logger.info("Waiting %s seconds before performing action"
+                                 "again '%s'", self.interval, self.config.name)
+                self.wait(self.interval)
+        except KeyboardInterrupt:
+            self.logger.debug("Thread '%s' interrupted", self.config.name)
+            self.cleanup()
+            sys.exit(1)
+
+    def cleanup(self):
+        '''
+        Perform cleaning up actions before termination.
+        '''
+        pass
+
+    def prepare(self):
+        """
+        Do pre-mainloop initialization of the source and dest,
+        for example logging in.
+        """
+        pass
+
+
+class DestinationThread(IntervalThread):
+    """
+    This class is a thread that pulls reports from the datastore and sends them
+    to the actual destination (candlepin, Satellite, etc) using a manager
+    object.
+
+    This class should work so long as the destination is a Manager object.
+    """
+    def __init__(self, logger, config, source_keys=None, options=None,
+                 source=None, dest=None, terminate_event=None, interval=None,
+                 oneshot=False):
+        """
+        @param source_keys: A list of keys to be used to retrieve info from
+        the source
+        @type source_keys: list
+
+        @param source: The source to pull from
+        @type source: Datastore
+
+        @param dest: The destination object to use to actually send the data
+        @type dest: Manager
+        """
+        if not isinstance(source_keys, list):
+            raise ValueError("Source keys must be a list")
+        self.source_keys = source_keys
+        self.last_report_for_source = {}  # Source_key to hash of last report
+        self.options = options
+        super(DestinationThread, self).__init__(logger, config, source=source,
+                                                dest=dest,
+                                                terminate_event=terminate_event,
+                                                interval=interval,
+                                                oneshot=oneshot)
+        # The polling interval has not been implemented as configurable yet
+        # Until the config includes the polling_interval attribute
+        # this will end up being the interval.
+        try:
+            polling_interval = self.config.polling_interval
+        except AttributeError:
+            polling_interval = self.interval
+        self.polling_interval = polling_interval
+        # This is used when there is some reason to modify how long we wait
+        # EX when we get a 429 back from the server, this value will be the
+        # value of the retry_after header.
+        self.interval_modifier = 0
+
+    def _get_data(self):
+        """
+        Gets the latest report from the source for each source_key
+        @return: dict
+        """
+        reports = {}
+        for source_key in self.source_keys:
+            report = self.source.get(source_key, None)
+            if report.hash == self.last_report_for_source.get(source_key, None):
+                self.logger.debug('Duplicate report found, ignoring')
+                continue
+            reports[source_key] = report
+        return reports
+
+    def _send_data(self, data_to_send):
+        """
+        Processes the data_to_send and sends it using the dest object.
+        @param data_to_send: A dict of source_keys, report
+        @type: dict
+        """
+        if not data_to_send:
+            self.logger.debug('No data to send, waiting for next interval')
+            return
+        if isinstance(data_to_send, ErrorReport):
+            self.logger.info('Error report received, shutting down')
+            self._internal_terminate_event.set()
+            return
+
+        all_hypervisors = [] # All the Host-guest mappings together
+        DomainListReports = []  # Source_key to DomainListReport
+        reports_batched = []  # Reports put together and sent as one
+        sources_sent = []  # Sources we have dealt with this run
+
+        # Reports of different types are handled differently
+        for source_key, report in data_to_send.iteritems():
+            if isinstance(report, DomainListReport):
+                # These are sent one at a time to the destination
+                DomainListReports.append(source_key)
+                continue
+            if isinstance(report, HostGuestAssociationReport):
+                # These reports are put into one report to send at once
+                all_hypervisors.extend(report.association['hypervisors'])
+                # Keep track of those reports that we have
+                reports_batched.append(source_key)
+                continue
+            if isinstance(report, ErrorReport):
+                # These indicate an error that came from this source
+                # Log it and move along.
+                # if it was recoverable we'll get something else next time.
+                # if it was not recoverable we'll see this again from this
+                # source. Thus we'll just log this at the debug level.
+                self.logger.debug('ErrorReport received for source: %s' % source_key)
+                if self._oneshot:
+                    # Consider this source dealt with if we are in oneshot mode
+                    sources_sent.append(source_key)
+
+        if all_hypervisors:
+            # Modify the batched dict to be in the form expected for
+            # HostGuestAssociationReports
+            all_hypervisors = {'hypervisors': all_hypervisors}
+            batch_host_guest_report = HostGuestAssociationReport(self.config,
+                                                                 all_hypervisors)
+            result = None
+            while result is None:
+                try:
+                    result = self.dest.hypervisorCheckIn(batch_host_guest_report,
+                                                     options=self.options)
+                    break
+                except ManagerThrottleError as e:
+                    self.logger.debug("429 encountered while performing "
+                                      "hypervisor check in.\nTrying again in "
+                                      "%s" % e.retry_after)
+                    self.interval_modifier = e.retry_after
+                self.wait(wait_time=self.interval_modifier)
+                self.interval_modifier = 0
+            # Poll for async results if async
+            while batch_host_guest_report.state not in [
+                AbstractVirtReport.STATE_CANCELED,
+                AbstractVirtReport.STATE_FAILED,
+                AbstractVirtReport.STATE_FINISHED]:
+                if self.interval_modifier != 0:
+                    wait_time = self.interval_modifier
+                    self.interval_modifier = 0
+                else:
+                    wait_time = self.polling_interval
+                self.wait(wait_time=wait_time)
+                try:
+                    self.dest.check_report_state(batch_host_guest_report)
+                except ManagerThrottleError as e:
+                    self.logger.debug('429 encountered while checking job '
+                                      'state, checking again later')
+                    self.interval_modifier = e.retry_after
+
+            # If the batch report did not reach the finished state, we do not
+            #  want to update which report we last sent (as we might want to
+            #  try to send the same report again next time)
+            if batch_host_guest_report.state == \
+                    AbstractVirtReport.STATE_FINISHED:
+                # Update the hash of the info last sent for each source
+                # included in the successful report
+                for source_key in reports_batched:
+                    self.last_report_for_source[source_key] = data_to_send[
+                        source_key].hash
+                    sources_sent.append(source_key)
+
+        # Send each Domain Guest List Report if necessary
+        for source_key in DomainListReports:
+            report = data_to_send[source_key]
+            retry = True
+            while retry:  # Retry if we encounter a 429
+                try:
+                    self.dest.sendVirtGuests(report, options=self.options)
+                    sources_sent.append(source_key)
+                    self.last_report_for_source[source_key] = data_to_send[
+                        source_key].hash
+                    retry = False
+                except ManagerError:
+                    self.logger.debug("Error in manager, unable to send virt "
+                                      "guests for source: %s" % source_key)
+                    retry = False  # Only retry on 429
+                except ManagerThrottleError as e:
+                    self.logger.debug('429 encountered when sending virt '
+                                      'guests. Retrying after: %s' % e.retry_after)
+                    self.wait(wait_time=e.retry_after)
+
+        # Terminate this thread if we have sent one report for each source
+        if all(source_key in sources_sent for source_key in self.source_keys)\
+                and self._oneshot:
+            self.logger.debug('At least one report for each connected source '
+                              'has been sent. Terminating.')
+            self._internal_terminate_event.set()
+        if self._oneshot:
+            # Remove sources we have sent (or dealt with) so that we don't
+            # do extra work on the next run, should we have missed any sources
+            self.source_keys = [source_key for source_key in self.source_keys
+                                if source_key not in sources_sent]
+        return
+
+
+class Virt(IntervalThread):
+    """
     Virtualization backend abstract class.
 
     This class must be inherited for each of the virtualization backends.
 
     Run `start` method to start obtaining data about virtual guests. The data
-    will be pushed to the `queue` that is parameter of the `start` method.
+    will be pushed to the dest(ination) that is parameter of the `__init__`
+    method.
+    """
 
-    Note that this class is a subclass of `threading.Thread` class.
-    '''
-    def __init__(self, logger, config):
-        self.logger = logger
-        self.config = config
-        self._internal_terminate_event = Event()
-        super(Virt, self).__init__()
-        self.daemon = True
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Virt, self).__init__(logger, config, dest=dest,
+                                   terminate_event=terminate_event,
+                                   interval=interval, oneshot=oneshot)
 
     def __repr__(self):
         return '{1}({0.logger!r}, {0.config!r})'.format(self, self.__class__.__name__)
 
     @classmethod
-    def fromConfig(cls, logger, config):
+    def from_config(cls, logger, config, dest,
+                    terminate_event=None, interval=None, oneshot=False):
         """
         Create instance of inherited class based on the config.
         """
@@ -300,48 +621,18 @@ class Virt(Thread):
 
         for subcls in cls.__subclasses__():
             if config.type == subcls.CONFIG_TYPE:
-                return subcls(logger, config)
+                return subcls(logger, config, dest,
+                              terminate_event=terminate_event,
+                              interval=interval, oneshot=oneshot)
         raise KeyError("Invalid config type: %s" % config.type)
 
-    def start(self, queue, terminate_event, interval=None, oneshot=False):  # pylint: disable=W0221
-        '''
-        Start obtaining data from the hypervisor/host system. The data will
-        be fetched (as instances of AbstractVirtReport subclasses) to the
-        `queue` parameter (which should be instance of `Queue.Queue` object.
-
-        `terminate_event` is `threading.Event` instance and will be set when
-        the thread should be terminated.
-
-        `interval` parameter determines maximal interval, how ofter should
-        the data be reported. If the virt backend supports events, it might
-        be less often.
-
-        If `oneshot` parameter is True, the data will be reported only once
-        and the thread will be terminated after that.
-        '''
-        self._queue = queue
-        self._terminate_event = terminate_event
-        if interval is not None:
-            self._interval = interval
-        else:
-            self._interval = DefaultInterval
-        self._oneshot = oneshot
-        super(Virt, self).start()
-
-    def start_sync(self, queue, terminate_event, interval=None, oneshot=False):
+    def start_sync(self):
         '''
         This method is same as `start()` but runs synchronously, it does NOT
         create new thread.
 
         Use it only in specific cases!
         '''
-        self._queue = queue
-        self._terminate_event = terminate_event
-        if interval is not None:
-            self._interval = interval
-        else:
-            self._interval = DefaultInterval
-        self._oneshot = oneshot
         self._run()
 
     def _get_report(self):
@@ -350,96 +641,21 @@ class Virt(Thread):
         else:
             return DomainListReport(self.config, self.listDomains())
 
-    def wait(self, wait_time):
-        '''
-        Wait `wait_time` seconds, could be interrupted by setting _terminate_event or _internal_terminate_event.
-        '''
-        for i in range(wait_time):
-            if self.is_terminated():
-                break
-            time.sleep(1)
+    def _get_data(self):
+        """
+        Gathers the data from the source.
+        Could be overridden to specify how to get data other than a report.
+        For example in destination threads.
+        @return: The data from the source to be passed along to the dest
+        """
+        return self._get_report()
 
-    def stop(self):
-        self._internal_terminate_event.set()
-
-    def is_terminated(self):
-        return self._internal_terminate_event.is_set() or self._terminate_event.is_set()
-
-    def enqueue(self, report):
+    def _send_data(self, data_to_send):
         if self.is_terminated():
             sys.exit(0)
-        self.logger.debug('Report for config "%s" gathered, putting to queue for sending', report.config.name)
-        self._queue.put(report)
-
-    def run(self):
-        '''
-        Wrapper around `_run` method that just catches the error messages.
-        '''
-        self.logger.debug("Virt backend '%s' started", self.config.name)
-        try:
-            while not self.is_terminated():
-                has_error = False
-                try:
-                    self._run()
-                except VirtError as e:
-                    if not self.is_terminated():
-                        self.logger.error("Virt backend '%s' fails with error: %s", self.config.name, str(e))
-                        has_error = True
-                except Exception:
-                    if not self.is_terminated():
-                        self.logger.exception("Virt backend '%s' fails with exception:", self.config.name)
-                        has_error = True
-
-                if self._oneshot:
-                    if has_error:
-                        self.enqueue(ErrorReport(self.config))
-                    self.logger.debug("Virt backend '%s' stopped after sending one report", self.config.name)
-                    return
-
-                if self.is_terminated():
-                    self.logger.debug("Virt backend '%s' terminated", self.config.name)
-                    return
-
-                self.logger.info("Waiting %s seconds before retrying backend '%s'", self._interval, self.config.name)
-                self.wait(self._interval)
-        except KeyboardInterrupt:
-            self.logger.debug("Virt backend '%s' interrupted", self.config.name)
-            self.cleanup()
-            sys.exit(1)
-
-    def _run(self):
-        '''
-        Run the endless loop that will fill the `_queue` with reports.
-
-        This method could be reimplemented in subclass to provide
-        it's own way of waiting for changes (like event monitoring)
-        '''
-        self.prepare()
-        while not self.is_terminated():
-            start_time = datetime.now()
-            report = self._get_report()
-            self.enqueue(report)
-            if self._oneshot:
-                break
-            end_time = datetime.now()
-
-            delta = end_time - start_time
-            # for python2.6, 2.7 has total_seconds method
-            delta_seconds = ((delta.days * 86400 + delta.seconds) * 10**6 + delta.microseconds) / 10**6
-
-            wait_time = self._interval - int(delta_seconds)
-
-            if wait_time < 0:
-                self.logger.debug("Getting the host/guests association took too long, interval waiting is skipped")
-                continue
-
-            self.wait(wait_time)
-
-    def prepare(self):
-        '''
-        Do pre-mainloop initialization of the backend, for example logging in.
-        '''
-        pass
+        self.logger.debug('Report for config "%s" gathered, placing in '
+                          'datastore', data_to_send.config.name)
+        self.dest.put(data_to_send)
 
     def isHypervisor(self):
         """
@@ -463,9 +679,3 @@ class Virt(Thread):
         return value of isHypervisor method.
         '''
         raise NotImplementedError('This should be reimplemented in subclass')
-
-    def cleanup(self):
-        '''
-        Perform cleaning up actions before termination.
-        '''
-        pass

--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -25,8 +25,12 @@ class Xen(virt.Virt):
     # Register for events on all classes
     event_types = ["host", "vm"]
 
-    def __init__(self, logger, config):
-        super(Xen, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Xen, self).__init__(logger, config, dest,
+                                  terminate_event=terminate_event,
+                                  interval=interval,
+                                  oneshot=oneshot)
         self.url = config.server
         self.username = config.username
         self.password = config.password
@@ -186,8 +190,8 @@ class Xen(virt.Virt):
 
             if initial or len(events) > 0 or delta > 0:
                 assoc = self.getHostGuestMapping()
-                self.enqueue(virt.HostGuestAssociationReport(self.config, assoc))
-                next_update = time() + self._interval
+                self._send_data(virt.HostGuestAssociationReport(self.config, assoc))
+                next_update = time() + self.interval
                 initial = False
 
             if self._oneshot:


### PR DESCRIPTION
This PR changes a number of things. Firstly common functionality between the Virt class (and subclasses) and what would be the Destination Thread class has been pulled out and put into a new super class for both IntervalThread. Secondly, I have implemented a DestinationThread class that should be able to use any existing manager to send reports gathered from the datastore (by name) to the right endpoints. Thirdly, tests have been added for the new DestinationThread (and updated for the Virt subclasses).

With any luck, this will be the second to last PR before the interval design will be functional.