### PR TITLE
Update the spec file for builds on more downstream platforms

### DIFF
--- a/virt-who.spec
+++ b/virt-who.spec
@@ -1,4 +1,8 @@
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7)
+%if !%{use_systemd}
+%global __python2 %{__python}
+%global python2_sitelib %{python_sitelib}
+%endif
 
 Name:           virt-who
 Version:        0.19


### PR DESCRIPTION
Platforms that do not use systemd we will assume also will not
understand the macro %{__python2} or %{__python2_sitelib}