### PR TITLE
Bring it all together with interval threads!

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -322,8 +322,8 @@ type=esx
                 **TestReadingConfigs.dest_options_2)
 
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]
         }
 
         manager = ConfigManager(self.logger, self.config_dir)
@@ -352,8 +352,8 @@ type=esx
         expected_dest = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_1)
 
-        expected_mapping = {expected_dest: set([config_1['name'],
-                                                config_2['name']])}
+        expected_mapping = {expected_dest: [config_1['name'],
+                                            config_2['name']]}
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
@@ -387,8 +387,8 @@ type=esx
         expected_dest_2 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_2)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])  # config_2['name'] ==
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]  # config_2['name'] ==
                                                  # config_1['name']
         }
 
@@ -405,7 +405,7 @@ type=esx
         expected_dest_1 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_1)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']])
+            expected_dest_1: [config_1['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -424,8 +424,8 @@ type=esx
         expected_dest_2 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_2)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -464,9 +464,9 @@ type=esx
         expected_dest_3 = Satellite6DestinationInfo(**dest_options_3)
 
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name'], config_3['name']]),
-            expected_dest_3: set([config_4['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name'], config_3['name']],
+            expected_dest_3: [config_4['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -477,7 +477,6 @@ type=esx
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
-
 
     def testLibvirtConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:

--- a/tests/test_virt_intervalthread.py
+++ b/tests/test_virt_intervalthread.py
@@ -1,0 +1,186 @@
+from base import TestBase
+
+from mock import patch, Mock, sentinel, call
+from virtwho.virt import IntervalThread
+from threading import Event
+from datetime import datetime
+
+class TestIntervalThreadTiming(TestBase):
+    """
+    This is a group of tests intended to test the timing of the interval thread.
+    """
+
+    def setUp(self):
+        time_patcher = patch('time.sleep')
+        self.mock_time = time_patcher.start()
+        event_patcher = patch('virtwho.virt.virt.Event')
+        self.mock_internal_terminate_event = event_patcher.start().return_value
+        self.mock_internal_terminate_event.is_set.return_value = False
+        self.addCleanup(time_patcher.stop)
+        self.addCleanup(event_patcher.stop)
+
+        # default mock objects that can be passed into a new interval thread
+        self.config = Mock()
+        self.source = Mock()
+        self.dest = Mock()
+        self.terminate_event = Mock()
+        self.terminate_event.is_set.return_value = False
+        self.interval = 2
+        self.oneshot = True
+
+        self._get_data_return = sentinel.default_data_to_send
+        self._send_data_return = sentinel.default_send_data_return
+
+    def setup_interval_thread(self, **kwargs):
+        """
+        Sets up an interval thread class with mocks of unimplemented methods
+        to allow testing of the base implementation of those methods that have
+        concrete implementations.
+        """
+        logger = kwargs.get('logger', self.logger)
+        config = kwargs.get('config', self.config)
+        source = kwargs.get('source', self.source)
+        dest = kwargs.get('dest', self.dest)
+        terminate_event = kwargs.get('terminate_event', self.terminate_event)
+        interval = kwargs.get('interval', self.interval)
+        oneshot = kwargs.get('oneshot', self.oneshot)
+
+        interval_thread = IntervalThread(logger, config, source, dest,
+                                         terminate_event, interval, oneshot)
+
+        mock_get_data_impl = kwargs.get('mock_get_data', None)
+        if mock_get_data_impl is None:
+            mock_get_data_impl = Mock()
+            mock_get_data_impl.return_value = self._get_data_return
+
+        mock_send_data_impl = kwargs.get('mock_send_data', None)
+        if mock_send_data_impl is None:
+            mock_send_data_impl = Mock()
+            mock_send_data_impl.return_value = self._send_data_return
+
+        interval_thread._get_data = mock_get_data_impl
+        interval_thread._send_data = mock_send_data_impl
+
+        return interval_thread
+
+
+    def test__run(self):
+        """
+        Tests the timing of the _run method
+        """
+        oneshot = False
+        interval = 20  # Seconds
+        start_time = datetime(1, 1, 1, 1, 1)
+        time_taken = 10  # seconds, must be less than 60
+        end_time = datetime(start_time.year, start_time.month,
+                            start_time.day, start_time.hour, start_time.minute,
+                            start_time.second + time_taken,
+                            start_time.microsecond, start_time.tzinfo)
+        expected_wait_time = interval - time_taken
+        with patch('virtwho.virt.virt.datetime') as patcher:
+            patcher.now = Mock(side_effect=[start_time, end_time])
+            interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                         interval=interval)
+            interval_thread.is_terminated = Mock(side_effect=[False, True])
+            interval_thread.wait = Mock()
+            interval_thread._run()
+            interval_thread._get_data.assert_called()
+            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread.wait.assert_has_calls([call(expected_wait_time)])
+
+    def test__run_send_takes_longer_than_interval(self):
+        """
+        Tests the timing of the _run method
+        """
+        oneshot = False
+        interval = 20  # Seconds
+        start_time = datetime(1, 1, 1, 1, 1)
+        time_taken = 21  # seconds, must be less than 60
+        end_time = datetime(start_time.year, start_time.month,
+                            start_time.day, start_time.hour, start_time.minute,
+                            start_time.second + time_taken,
+                            start_time.microsecond, start_time.tzinfo)
+        with patch('virtwho.virt.virt.datetime') as patcher:
+            patcher.now = Mock(side_effect=[start_time, end_time])
+            interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                         interval=interval)
+            interval_thread.is_terminated = Mock(side_effect=[False, True])
+            interval_thread.wait = Mock()
+            interval_thread._run()
+            interval_thread._get_data.assert_called()
+            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread.wait.assert_not_called()
+
+
+    def test_wait(self):
+        interval_thread = self.setup_interval_thread()
+        interval_thread.is_terminated = Mock()
+        interval_thread.is_terminated.return_value = False
+        # The total time we expect to be waited
+        wait_time = 10
+        # The time we expect to be waited each interval
+        expected_wait_interval = 1
+        expected_calls = [call(expected_wait_interval) for x in range(wait_time)]
+
+        interval_thread.wait(wait_time=wait_time)
+        self.assertEquals(interval_thread.is_terminated.call_count, wait_time)
+        self.mock_time.assert_has_calls(expected_calls)
+
+    def test_is_terminated_terminate_event(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        self.terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_is_terminated_internal_terminate_event(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        self.mock_internal_terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_is_terminated_both_events(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        interval_thread._internal_terminate_event.is_set.return_value = True
+        self.terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_stop(self):
+        interval_thread = self.setup_interval_thread()
+        interval_thread.stop()
+        self.mock_internal_terminate_event.set.assert_called()
+
+    def test_run(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, False, True])
+        interval_thread._run = Mock()
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_has_calls([call(interval)])
+
+    def test_run_has_error(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, False,
+                                                          False, True])
+        interval_thread._run = Mock(side_effect=Exception)
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_has_calls([call(interval)])
+
+    def test_run_has_error_and_terminated(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, True,
+                                                          True, True])
+        interval_thread._run = Mock(side_effect=Exception)
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_not_called()

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -26,7 +26,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config
+from virtwho.config import Config, ConfigManager
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,
@@ -41,6 +41,10 @@ class TestOptions(TestBase):
 
     def setUp(self):
         self.clearEnv()
+
+    def tearDown(self):
+        self.clearEnv()
+        super(TestBase, self).tearDown()
 
     def clearEnv(self):
         for key in os.environ.keys():
@@ -233,298 +237,40 @@ class TestOptions(TestBase):
                             continue
                         self.assertRaises(OptionError, parseOptions)
 
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.config.parseFile')
-    def test_sending_guests(self, parseFile, fromOptions, from_config, getLogger):
-        self.setUpParseFile(parseFile)
-        options = Mock()
-        options.oneshot = True
-        options.interval = 0
-        options.print_ = False
-        fake_virt = Mock()
-        fake_virt.CONFIG_TYPE = 'esx'
-        test_hypervisor = Hypervisor('test', guestIds=[Guest('guest1', fake_virt, 1)])
-        association = {'hypervisors': [test_hypervisor]}
-        options.log_dir = ''
-        options.log_file = ''
-        getLogger.return_value = sentinel.logger
+class TestExecutor(TestBase):
 
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-        config = Config("test", "esx", server="localhost", username="username",
-                        password="password", owner="owner", env="env")
-        expected_virt = Mock()
-        expected_virt.config = config
-        from_config.return_value = expected_virt
-        virtwho.configManager.addConfig(config)
-        test_queue = Queue()
-        virtwho.queue = test_queue
-        virtwho.queue.put(HostGuestAssociationReport(config, association))
-        virtwho.run()
+    @patch.object(Executor, 'terminate_threads')
+    @patch('virtwho.executor.time')
+    def test_wait_on_threads(self, mock_time, mock_terminate_threads):
+        """
+        Tests that, given no kwargs, the wait_on_threads method will wait until
+        all threads is_terminated method returns True.
+        Please note that a possible consequence of something going wrong in
+        the wait on threads method (with no kwargs) could cause this test to
+        never quit.
+        """
+        # Create a few mock threads
+        # The both will return False the first time is_terminated is called
+        # Only the second mock thread will wait not return True until the
+        # third call of is_terminated
+        mock_thread1 = Mock()
+        mock_thread1.is_terminated = Mock(side_effect=[False, True])
+        mock_thread2 = Mock()
+        mock_thread2.is_terminated = Mock(side_effect=[False, False, True])
 
-        from_config.assert_called_with(sentinel.logger, config, test_queue,
-                                       terminate_event=virtwho.terminate_event,
-                                       interval=options.interval,
-                                       oneshot=options.oneshot)
-        self.assertTrue(from_config.return_value.start.called)
-        fromOptions.assert_called_with(self.logger, options, ANY)
+        threads = [mock_thread1, mock_thread2]
 
+        mock_time.sleep = Mock()
+        Executor.wait_on_threads(threads)
+        mock_time.sleep.assert_has_calls([
+            call(1),
+            call(1),
+        ])
+        mock_terminate_threads.assert_not_called()
 
-class TestSend(TestBase):
-    def setUp(self):
-        self.config = Config('config', 'esx', server='localhost',
-                             username='username', password='password',
-                             owner='owner', env='env', log_dir='', log_file='')
-        self.second_config = Config('second_config', 'esx', server='localhost',
-                                    username='username', password='password',
-                                    owner='owner', env='env', log_dir='',
-                                    log_file='')
-        fake_virt = Mock()
-        fake_virt.CONFIG_TYPE = 'esx'
-        guests = [Guest('guest1', fake_virt, 1)]
-        test_hypervisor = Hypervisor('test', guestIds=[Guest('guest1', fake_virt, 1)])
-        assoc = {'hypervisors': [test_hypervisor]}
-        self.fake_domain_list = DomainListReport(self.second_config, guests)
-        self.fake_report = HostGuestAssociationReport(self.config, assoc)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_report_hash_added_after_send(self, from_config, fromOptions, getLogger):
-        # Side effect for from_config
-        def fake_virts(logger, config, dest, **kwargs):
-            new_fake_virt = Mock()
-            new_fake_virt.config.name = config.name
-            return new_fake_virt
-
-        from_config.side_effect = fake_virts
-        options = Mock()
-        options.interval = 0
-        options.oneshot = True
-        options.print_ = False
-        options.log_file = ''
-        options.log_dir = ''
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-
-        def send(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            return True
-        virtwho.send = Mock(side_effect=send)
-        queue = Queue()
-        virtwho.queue = queue
-        virtwho.retry_after = 1
-        virtwho.configManager.addConfig(self.config)
-        virtwho.configManager.addConfig(self.second_config)
-        queue.put(self.fake_report)
-        queue.put(self.fake_domain_list)
-        virtwho.run()
-
-        self.assertEquals(virtwho.send.call_count, 2)
-        self.assertEqual(virtwho.last_reports_hash[self.config.name], self.fake_report.hash)
-        self.assertEqual(virtwho.last_reports_hash[self.second_config.name], self.fake_domain_list.hash)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_same_report_filtering(self, from_config, fromOptions, getLogger):
-        def fake_virts(logger, config, dest, **kwargs):
-            new_fake_virt = Mock()
-            new_fake_virt.config.name = config.name
-            return new_fake_virt
-
-        from_config.side_effect = fake_virts
-        options = Mock()
-        options.interval = 0
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-
-        queue = Queue()
-        # Create another report with same hash
-        report2 = HostGuestAssociationReport(self.config, self.fake_report.association)
-        self.assertEqual(self.fake_report.hash, report2.hash)
-
-        def send(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            # Put second report when the first is done
-            queue.put(report2)
-            return True
-        virtwho.send = Mock(side_effect=send)
-        virtwho.queue = queue
-        virtwho.retry_after = 1
-        virtwho.configManager.addConfig(self.config)
-        queue.put(self.fake_report)
-        virtwho.run()
-
-        self.assertEquals(virtwho.send.call_count, 1)
-
-    @patch('time.time')
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_send_current_report(self, from_config, fromOptions, getLogger, time):
-        initial = 10
-        time.side_effect = [initial, initial]
-
-        fromOptions.return_value = Mock()
-        options = Mock()
-        options.interval = 6
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-        virtwho.oneshot_remaining = ['config_name']
-
-        config = Mock()
-        config.hash = "config_hash"
-        config.name = "config_name"
-
-        virtwho.send = Mock()
-        virtwho.send.return_value = True
-        report = HostGuestAssociationReport(config, {'hypervisors': {}})
-        report.state = AbstractVirtReport.STATE_PROCESSING
-        virtwho.queued_reports[config.name] = report
-
-        virtwho.send_current_report()
-
-        def check_report_state(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-        virtwho.check_report_state = Mock(side_effect=check_report_state)
-        virtwho.check_reports_state()
-
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + options.interval)
-
-    @patch('time.time')
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_send_current_report_with_429(self, from_config, fromOptions, getLogger, time):
-        initial = 10
-        retry_after = 2
-        time.return_value = initial
-
-        fromOptions.return_value = Mock()
-        options = Mock()
-        options.interval = 6
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-
-        config = Mock()
-        config.hash = "config_hash"
-        config.name = "config_name"
-
-        report = HostGuestAssociationReport(config, {'hypervisors': []})
-        report.state = AbstractVirtReport.STATE_PROCESSING
-        virtwho.queued_reports[config.name] = report
-
-        virtwho.send = Mock()
-        virtwho.send.return_value = False
-        virtwho.send.side_effect = ManagerThrottleError(retry_after)
-
-        virtwho.send_current_report()
-
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + 60)
-        self.assertEquals(len(virtwho.queued_reports), 1)
-
-        retry_after = 120
-        virtwho.send.side_effect = ManagerThrottleError(retry_after)
-        virtwho.send_current_report()
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + retry_after * 2)
-        self.assertEquals(len(virtwho.queued_reports), 1)
-
-        def finish(x):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            return True
-        virtwho.send.side_effect = finish
-        virtwho.send_current_report()
-        retry_after = 60
-        self.assertEquals(virtwho.retry_after, retry_after)
-        self.assertEquals(virtwho.send_after, initial + options.interval)
-        self.assertEquals(len(virtwho.queued_reports), 0)
-
-
-class TestReload(TestBase):
-    def mock_virtwho(self):
-        options = Mock()
-        options.interval = 6
-        options.oneshot = False
-        options.print_ = False
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-        config = Config("env/cmdline", 'libvirt')
-        virtwho.configManager.addConfig(config)
-        virtwho.queue = Mock()
-        virtwho.send = Mock()
-        return virtwho
-
-    def assertStartStop(self, from_config):
-        ''' Make sure that Virt was started and stopped. '''
-        self.assertTrue(from_config.return_value.start.called)
-        self.assertTrue(from_config.return_value.stop.called)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_start_unregistered(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        virtwho.queue.get.side_effect = [DomainListReport(virtwho.configManager.configs[0], []), Empty, 'reload']
-        virtwho.send.side_effect = ManagerFatalError
-        # When not registered, it should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-        # queue.get should be called 3 times: report, nonblocking reading
-        # of remaining reports and after ManagerFatalError wait indefinately
-        self.assertEqual(virtwho.queue.get.call_count, 3)
-        # It should wait blocking for the reload
-        virtwho.queue.get.assert_has_calls([call(block=True)])
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_exit_after_unregister(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send two reports and then 'exit'
-        virtwho.queue.get.side_effect = [report, Empty, report, Empty, 'exit']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [True, ManagerFatalError]
-        # _main should exit normally
-        _main(virtwho)
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_reload_after_unregister(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send two reports and then 'reload'
-        virtwho.queue.get.side_effect = [report, Empty, report, Empty, 'reload']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [True, ManagerFatalError]
-        # _main should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_reload_after_register(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send report and then 'reload'
-        virtwho.queue.get.side_effect = [report, Empty, 'reload']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [ManagerFatalError, True]
-        # _main should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-
-        self.assertEqual(virtwho.queue.get.call_count, 3)
-        # It should wait blocking for the reload
-        virtwho.queue.get.assert_has_calls([call(block=True)])
-        self.assertStartStop(from_config)
+    def test_terminate_threads(self):
+        threads = [Mock(), Mock()]
+        Executor.terminate_threads(threads)
+        for mock_thread in threads:
+            mock_thread.stop.assert_called()
+            mock_thread.join.assert_called()

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -8,11 +8,13 @@ import sys
 from virtwho import log, MinimumSendInterval
 
 from virtwho.config import ConfigManager
+from virtwho.datastore import Datastore
 from virtwho.manager import (
     Manager, ManagerThrottleError, ManagerError, ManagerFatalError)
 from virtwho.virt import (
     AbstractVirtReport, ErrorReport, DomainListReport,
-    HostGuestAssociationReport, Virt)
+    HostGuestAssociationReport, Virt, DestinationThread,
+    info_to_destination_class)
 
 try:
     from collections import OrderedDict
@@ -38,317 +40,198 @@ class Executor(object):
         self.options = options
         self.terminate_event = Event()
         self.virts = []
+        self.destinations = []
 
         # Queue for getting events from virt backends
-        self.queue = None
-
-        # Dictionary with mapping between config names and report hashes,
-        # used for checking if the report changed from last time
-        self.last_reports_hash = {}
-        # How long should we wait between reports sent to server
-        self.retry_after = MinimumSendInterval
-        # This counts the number of responses of http code 429
-        # received between successfully sent reports
-        self._429_count = 0
+        self.datastore = Datastore()
         self.reloading = False
-
-        # Reports that are queued for sending
-        self.queued_reports = OrderedDict()
-
-        # Name of configs that wasn't reported in oneshot mode
-        self.oneshot_remaining = set()
-
-        # Reports that are currently processed by server
-        self.reports_in_progress = []
 
         self.configManager = ConfigManager(self.logger, config_dir)
 
         for config in self.configManager.configs:
             logger.debug("Using config named '%s'" % config.name)
 
-        self.send_after = time.time()
-
-    def check_report_state(self, report):
-        ''' Check state of one report that is being processed on server. '''
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.check_report_state(report)
-
-    def check_reports_state(self):
-        ''' Check status of the reports that are being processed on server. '''
-        if not self.reports_in_progress:
-            return
-        updated = []
-        for report in self.reports_in_progress:
-            self.check_report_state(report)
-            if report.state == AbstractVirtReport.STATE_CREATED:
-                self.logger.warning("Can't check status of report that is not yet sent")
-            elif report.state == AbstractVirtReport.STATE_PROCESSING:
-                updated.append(report)
-            else:
-                self.report_done(report)
-        self.reports_in_progress = updated
-
-    def send_current_report(self):
-        name, report = self.queued_reports.popitem(last=False)
-        return self.send_report(name, report)
-
-    def send_report(self, name, report):
-        try:
-            if self.send(report):
-                # Success will reset the 429 count
-                if self._429_count > 0:
-                    self._429_count = 1
-                    self.retry_after = MinimumSendInterval
-
-                self.logger.debug('Report for config "%s" sent', name)
-                if report.state == AbstractVirtReport.STATE_PROCESSING:
-                    self.reports_in_progress.append(report)
-                else:
-                    self.report_done(report)
-            else:
-                report.state = AbstractVirtReport.STATE_FAILED
-                self.logger.debug('Report from "%s" failed to sent', name)
-                self.report_done(report)
-        except ManagerThrottleError as e:
-            self.queued_reports[name] = report
-            self._429_count += 1
-            self.retry_after = max(MinimumSendInterval, e.retry_after * self._429_count)
-            self.send_after = time.time() + self.retry_after
-            self.logger.debug('429 received, waiting %s seconds until sending again', self.retry_after)
-
-    def report_done(self, report):
-        name = report.config.name
-        self.send_after = time.time() + self.options.interval
-        if report.state == AbstractVirtReport.STATE_FINISHED:
-            self.last_reports_hash[name] = report.hash
-
-        if self.options.oneshot:
-            try:
-                self.oneshot_remaining.remove(name)
-            except KeyError:
-                pass
-
-    def send(self, report):
+    def _create_virt_backends(self):
         """
-        Send list of uuids to subscription manager
-
-        return - True if sending is successful, False otherwise
+        Create virts list with virt backend threads
         """
-        try:
-            if isinstance(report, DomainListReport):
-                self._sendGuestList(report)
-            elif isinstance(report, HostGuestAssociationReport):
-                self._sendGuestAssociation(report)
-            else:
-                self.logger.warn("Unable to handle report of type: %s", type(report))
-        except ManagerError as e:
-            self.logger.error("Unable to send data: %s", str(e))
-            return False
-        except ManagerFatalError:
-            raise
-        except ManagerThrottleError:
-            raise
-        except socket.error as e:
-            if e.errno == errno.EINTR:
-                self.logger.debug("Communication with subscription manager interrupted")
-            return False
-        except Exception as e:
-            if self.reloading:
-                # We want to skip error reporting when reloading,
-                # it is caused by interrupted syscall
-                self.logger.debug("Communication with subscription manager interrupted")
-                return False
-            exceptionCheck(e)
-            self.logger.exception("Error in communication with subscription manager:")
-            return False
-        return True
-
-    def _sendGuestList(self, report):
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.sendVirtGuests(report, self.options)
-
-    def _sendGuestAssociation(self, report):
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.hypervisorCheckIn(report, self.options)
-
-    def run(self):
-        self.reloading = False
-        if not self.options.oneshot:
-            self.logger.debug("Starting infinite loop with %d seconds interval", self.options.interval)
-
-        # Queue for getting events from virt backends
-        if self.queue is None:
-            self.queue = Queue()
-
-        # Run the virtualization backends
-        self.virts = []
+        virts = []
         for config in self.configManager.configs:
             try:
                 logger = log.getLogger(config=config)
-                virt = Virt.from_config(logger, config, self.queue,
+                virt = Virt.from_config(logger, config, self.datastore,
                                         terminate_event=self.terminate_event,
                                         interval=self.options.interval,
                                         oneshot=self.options.oneshot)
             except Exception as e:
                 self.logger.error('Unable to use configuration "%s": %s', config.name, str(e))
                 continue
-            # Run the thread
-            virt.start()
-            self.virts.append(virt)
+            virts.append(virt)
+        return virts
 
-        # This set is used both for oneshot mode and to bypass rate-limit
-        # when virt-who is starting
-        self.oneshot_remaining = set(virt.config.name for virt in self.virts)
+    def _create_destinations(self):
+        """Populate self.destinations with a list of  list with them
+
+            @param reset: Whether to kill existing destinations or not, defaults
+            to false
+            @type: bool
+        """
+        dests = []
+        for info in self.configManager.dests:
+            # Dests should already include all destinations we want created
+            # at this time. This method will make no assumptions of creating
+            # defaults of any kind.
+            source_keys = self.configManager.dest_to_sources_map[info]
+            info.name = "destination_%s" % hash(info)
+            logger = log.getLogger(name=info.name)
+            manager = Manager.fromInfo(logger, self.options, info)
+            dest_class = info_to_destination_class[type(info)]
+            dest = dest_class(config=info, logger=logger,
+                              source_keys=source_keys,
+                              options=self.options,
+                              source=self.datastore, dest=manager,
+                              terminate_event=self.terminate_event,
+                              interval=self.options.interval,
+                              oneshot=self.options.oneshot)
+            dests.append(dest)
+        return dests
+
+    @staticmethod
+    def wait_on_threads(threads, max_wait_time=None, kill_on_timeout=False):
+        """
+        Wait for each of the threads in the list to be terminated
+        @param threads: A list of IntervalThread objects to wait on
+        @type threads: list
+
+        @param max_wait_time: An optional max amount of seconds to wait
+        @type max_wait_time: int
+
+        @param kill_on_timeout: An optional arg that, if truthy and
+        max_wait_time is defined and exceeded, cause this method to attempt
+        to terminate and join the threads given it.
+        @type kill_on_timeout: bool
+
+        @return: A list of threads that have not quit yet. Without a
+        max_wait_time this list is always empty (or we are stuck waiting).
+        With a max_wait_time this list will include those threads that have
+        not quit yet.
+        @rtype: list
+        """
+        total_waited = 0
+        threads_not_terminated = list(threads)
+        while len(threads_not_terminated) > 0:
+            if max_wait_time is not None and total_waited > max_wait_time:
+                if kill_on_timeout:
+                    Executor.terminate_threads(threads_not_terminated)
+                    return []
+                return threads_not_terminated
+            for thread in threads_not_terminated:
+                if thread.is_terminated():
+                    threads_not_terminated.remove(thread)
+            if not threads_not_terminated:
+                break
+            time.sleep(1)
+            if max_wait_time is not None:
+                total_waited += 1
+        return threads_not_terminated
+
+    @staticmethod
+    def terminate_threads(threads):
+        for thread in threads:
+            thread.stop()
+            thread.join()
+
+    def run_oneshot(self):
+        # Start all sources
+        self.virts = self._create_virt_backends()
 
         if len(self.virts) == 0:
             err = "virt-who can't be started: no suitable virt backend found"
             self.logger.error(err)
+            self.terminate()
             sys.exit(err)
 
-        # queued reports depend on OrderedDict feature that if key exists
-        # when setting an item, it will remain in the same order
-        self.queued_reports.clear()
+        self.destinations = self._create_destinations()
 
-        # Clear last reports, we need to resend them when reloaded
-        self.last_reports_hash.clear()
+        if len(self.destinations) == 0:
+            err = "virt-who can't be started: no suitable destinations found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
 
-        # List of reports that are being processed by server
-        self.reports_in_progress = []
+        for thread in self.virts:
+            thread.start()
 
-        # Send the first report immediately
-        self.send_after = time.time()
+        Executor.wait_on_threads(self.virts)
 
-        while not self.terminate_event.is_set():
-            if self.reports_in_progress:
-                # Check sent report status regularly
-                timeout = 1
-            elif time.time() > self.send_after:
-                if self.queued_reports:
-                    # Reports are queued and we can send them right now,
-                    # don't wait in queue
-                    timeout = 0
-                else:
-                    # No reports in progress or queued and we can send report
-                    # immediately, we can wait for report as long as we want
-                    timeout = 3600
-            else:
-                # We can't send report right now, wait till we can
-                timeout = max(1, self.send_after - time.time())
-
-            # Wait for incoming report from virt backend or for timeout
-            try:
-                report = self.queue.get(block=True, timeout=timeout)
-            except Empty:
-                report = None
-            except IOError:
-                continue
-
-            # Read rest of the reports from the queue in order to remove
-            # obsoleted reports from same virt
-            while True:
-                if isinstance(report, ErrorReport):
-                    if self.options.oneshot:
-                        # Don't hang on the failed backend
-                        try:
-                            self.oneshot_remaining.remove(report.config.name)
-                        except KeyError:
-                            pass
-                        self.logger.warn('Unable to collect report for config "%s"', report.config.name)
-                elif isinstance(report, AbstractVirtReport):
-                    if self.last_reports_hash.get(report.config.name, None) == report.hash:
-                        self.logger.info('Report for config "%s" hasn\'t changed, not sending', report.config.name)
-                    else:
-                        if report.config.name in self.oneshot_remaining:
-                            # Send the report immediately
-                            self.oneshot_remaining.remove(report.config.name)
-                            if not self.options.print_:
-                                self.send_report(report.config.name, report)
-                            else:
-                                self.queued_reports[report.config.name] = report
-                        else:
-                            self.queued_reports[report.config.name] = report
-                elif report in ['exit', 'reload']:
-                    # Reload and exit reports takes priority, do not process
-                    # any other reports
-                    break
-
-                # Get next report from queue
-                try:
-                    report = self.queue.get(block=False)
-                except Empty:
-                    break
-
-            if report == 'exit':
-                break
-            elif report == 'reload':
-                self.stop_virts()
-                raise ReloadRequest()
-
-            self.check_reports_state()
-
-            if not self.reports_in_progress and self.queued_reports and time.time() > self.send_after:
-                # No report is processed, send next one
-                if not self.options.print_:
-                    self.send_current_report()
-
-            if self.options.oneshot and not self.oneshot_remaining and not self.reports_in_progress:
-                break
-
-        self.queue = None
-        self.stop_virts()
-
-        self.virt = []
         if self.options.print_:
-            return self.queued_reports
+            to_print = {}
+            for source in self.configManager.sources:
+                try:
+                    report = self.datastore.get(source)
+                    config = report.config
+                    to_print[config] = report
+                except KeyError:
+                    self.logger.info('Unable to retrieve report for source '
+                                     '\"%s\" for printing' % source)
+            return to_print
 
-    def stop_virts(self):
-        for virt in self.virts:
-            virt.stop()
-            virt.join()
-        self.virts = []
+        for thread in self.destinations:
+            thread.start()
+
+        Executor.wait_on_threads(self.destinations)
+
+    def run(self):
+        self.logger.debug("Starting infinite loop with %d seconds interval", self.options.interval)
+
+        # Need to update the dest to source mapping of the configManager object
+        # here because of the way that main reads the config from the command
+        # line
+        # TODO: Update dests to source map on addition or removal of configs
+        self.configManager.update_dest_to_source_map()
+        # Start all sources
+        self.virts = self._create_virt_backends()
+
+        if len(self.virts) == 0:
+            err = "virt-who can't be started: no suitable virt backend found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
+
+        self.destinations = self._create_destinations()
+        if len(self.destinations) == 0:
+            err = "virt-who can't be started: no suitable destinations found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
+
+        for thread in self.virts:
+            thread.start()
+
+        for thread in self.destinations:
+            thread.start()
+
+        # Interruptibly wait on the other threads to be terminated
+        self.wait_on_threads(self.destinations)
+
+        self.terminate()
+
+    def stop_threads(self):
+        self.terminate_event.set()
+        self.terminate_threads(self.virts)
+        self.terminate_threads(self.destinations)
 
     def terminate(self):
         self.logger.debug("virt-who is shutting down")
-
-        # Terminate the backends before clearing the queue, the queue must be empty
-        # to end a child process, otherwise it will be stuck in queue.put()
-        self.terminate_event.set()
-        # Give backends some time to terminate properly
-        time.sleep(0.5)
-
-        if self.queue:
-            # clear the queue and put "exit" there
-            try:
-                while True:
-                    self.queue.get(False)
-            except Empty:
-                pass
-            self.queue.put("exit")
-
-        # Give backends some more time to terminate properly
-        time.sleep(0.5)
-
-        self.stop_virts()
+        self.stop_threads()
+        self.virts = []
+        self.destinations = []
+        self.datastore = None
 
     def reload(self):
-        self.logger.warn("virt-who reload")
-        # Set the terminate event in all the virts
-        for virt in self.virts:
-            virt.stop()
-        # clear the queue and put "reload" there
-        try:
-            while True:
-                self.queue.get(False)
-        except Empty:
-            pass
-        self.reloading = True
-        self.queue.put("reload")
-
-
-def exceptionCheck(e):
-    try:
-        # This happens when connection to server is interrupted (CTRL+C or signal)
-        if e.args[0] == errno.EALREADY:
-            exit(0)
-    except Exception:
-        pass
+        """
+        Causes all threads to be terminated in preparation for running again
+        """
+        self.stop_threads()
+        self.terminate_event.clear()
+        self.datastore = Datastore()

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -39,20 +39,18 @@ from virtwho.parser import parseOptions, OptionError
 from virtwho.password import InvalidKeyFile
 from virtwho.virt import DomainListReport, HostGuestAssociationReport
 
-
 try:
     from systemd.daemon import notify as sd_notify
 except ImportError:
     def sd_notify(status, unset_environment=False):
         pass
 
-
 # Disable Insecure Request warning from requests library
 try:
-    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+    requests.packages.urllib3.disable_warnings(
+        requests.packages.urllib3.exceptions.InsecureRequestWarning)
 except AttributeError:
     pass
-
 
 PIDFILE = "/var/run/virt-who.pid"
 
@@ -70,7 +68,8 @@ class PIDLock(object):
                 return True
             except OSError:
                 # Process no longer exists
-                print >>sys.stderr, "PID file exists but associated process does not, deleting PID file"
+                print >> sys.stderr, "PID file exists but associated process " \
+                                     "does not, deleting PID file"
                 os.remove(self.filename)
                 return False
         except Exception:
@@ -79,10 +78,12 @@ class PIDLock(object):
     def __enter__(self):
         # Write pid to pidfile
         try:
-            with os.fdopen(os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600), 'w') as f:
+            with os.fdopen(
+                    os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600),
+                    'w') as f:
                 f.write("%d" % os.getpid())
         except Exception as e:
-            print >>sys.stderr, "Unable to create pid file: %s" % str(e)
+            print >> sys.stderr, "Unable to create pid file: %s" % str(e)
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
@@ -104,6 +105,8 @@ def atexit_fn(*args, **kwargs):
 def reload(signal, stackframe):
     if executor:
         executor.reload()
+        raise ReloadRequest()
+    exit(1, status="virt-who cannot reload, exiting")
 
 
 def main():
@@ -111,13 +114,14 @@ def main():
     try:
         logger, options = parseOptions()
     except OptionError as e:
-        print >>sys.stderr, str(e)
+        print >> sys.stderr, str(e)
         exit(1, status="virt-who can't be started: %s" % str(e))
 
     lock = PIDLock(PIDFILE)
     if lock.is_locked():
-        msg = "virt-who seems to be already running. If not, remove %s" % PIDFILE
-        print >>sys.stderr, msg
+        msg = "virt-who seems to be already running. If not, remove %s" % \
+              PIDFILE
+        print >> sys.stderr, msg
         exit(1, status=msg)
 
     global executor
@@ -128,7 +132,8 @@ def main():
         exit(1, "virt-who can't be started: %s" % str(e))
 
     if options.virtType is not None:
-        config = Config("env/cmdline", options.virtType, executor.configManager._defaults, **options)
+        config = Config("env/cmdline", options.virtType,
+                        executor.configManager._defaults, **options)
         try:
             config.checkOptions(logger)
         except InvalidOption as e:
@@ -145,7 +150,8 @@ def main():
             logger.error(err)
             exit(1, err)
         except Exception as e:
-            logger.error('Config file "%s" skipped because of an error: %s', conffile, str(e))
+            logger.error('Config file "%s" skipped because of an error: %s',
+                         conffile, str(e))
             has_error = True
 
     if len(executor.configManager.configs) == 0:
@@ -158,11 +164,22 @@ def main():
         logger.info("No configurations found, using libvirt as backend")
         executor.configManager.addConfig(Config("env/cmdline", "libvirt"))
 
+    executor.configManager.update_dest_to_source_map()
+
+    if len(executor.configManager.dests) == 0:
+        if has_error:
+            err = "virt-who can't be started: no valid destination found"
+            logger.error(err)
+            exit(1, err)
+
     for config in executor.configManager.configs:
         if config.name is None:
-            logger.info('Using commandline or sysconfig configuration ("%s" mode)', config.type)
+            logger.info(
+                'Using commandline or sysconfig configuration ("%s" mode)',
+                config.type)
         else:
-            logger.info('Using configuration "%s" ("%s" mode)', config.name, config.type)
+            logger.info('Using configuration "%s" ("%s" mode)', config.name,
+                        config.type)
 
     logger.info("Using reporter_id='%s'", options.reporter_id)
     log.closeLogger(logger)
@@ -175,7 +192,8 @@ def main():
         signal.signal(signal.SIGHUP, reload)
         signal.signal(signal.SIGTERM, atexit_fn)
 
-        executor.logger = logger = log.getLogger(name='main', config=None, queue=True)
+        executor.logger = logger = log.getLogger(name='main', config=None,
+                                                 queue=True)
 
         sd_notify("READY=1\nMAINPID=%d" % os.getpid())
         while True:
@@ -187,50 +205,47 @@ def main():
 
 
 def _main(executor):
-    result = None
-    try:
-        result = executor.run()
-    except ManagerFatalError:
-        executor.stop_virts()
-        executor.logger.exception("Fatal error:")
-        if not executor.options.oneshot:
-            executor.logger.info("Waiting for reload signal")
-            # Wait indefinitely until we get reload or exit signal
-            while True:
-                report = executor.queue.get(block=True)
-                if report == 'reload':
-                    raise ReloadRequest()
-                elif report == 'exit':
-                    return 0
+    if executor.options.oneshot:
+        result = executor.run_oneshot()
 
-    if executor.options.print_:
-        if not result:
-            executor.logger.error("No hypervisor reports found")
-            return 1
-        hypervisors = []
-        for config, report in result.items():
-            if isinstance(report, DomainListReport):
-                hypervisors.append({
-                    'guests': [guest.toDict() for guest in report.guests]
-                })
-            elif isinstance(report, HostGuestAssociationReport):
-                for hypervisor in report.association['hypervisors']:
-                    h = OrderedDict((
-                        ('uuid', hypervisor.hypervisorId),
-                        ('guests', [guest.toDict() for guest in hypervisor.guestIds])
-                    ))
-                    if hypervisor.facts:
-                        h['facts'] = hypervisor.facts
-                    if hypervisor.name:
-                        h['name'] = hypervisor.name
-                    hypervisors.append(h)
-        data = json.dumps({
-            'hypervisors': hypervisors
-        })
-        executor.logger.debug("Associations found: %s", json.dumps({
-            'hypervisors': hypervisors
-        }, indent=4, sort_keys=True))
-        print(data)
+        if executor.options.print_:
+            if not result:
+                executor.logger.error("No hypervisor reports found")
+                return 1
+            hypervisors = []
+            for config, report in result.items():
+                if isinstance(report, DomainListReport):
+                    hypervisors.append({
+                        'guests': [guest.toDict() for guest in report.guests]
+                    })
+                elif isinstance(report, HostGuestAssociationReport):
+                    for hypervisor in report.association['hypervisors']:
+                        h = OrderedDict((
+                            ('uuid', hypervisor.hypervisorId),
+                            ('guests',
+                             [guest.toDict() for guest in hypervisor.guestIds])
+                        ))
+                        if hypervisor.facts:
+                            h['facts'] = hypervisor.facts
+                        if hypervisor.name:
+                            h['name'] = hypervisor.name
+                        hypervisors.append(h)
+            data = json.dumps({
+                'hypervisors': hypervisors
+            })
+            executor.logger.debug("Associations found: %s", json.dumps({
+                'hypervisors': hypervisors
+            }, indent=4, sort_keys=True))
+            print(data)
+        return 0
+
+    # We'll get here only if we're not in oneshot or print_ mode (which
+    # implies oneshot)
+
+    # There should not be a way for us to leave this method unless it is time
+    #  to exit
+    executor.run()
+
     return 0
 
 
@@ -250,7 +265,12 @@ def exit(code, status=None):
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             for v in executor.virts:
                 v.stop()
-                v.join()
+                if v.ident:
+                    v.join()
+            for d in executor.destinations:
+                d.stop()
+                if d.ident:
+                    d.join()
     if log.hasQueueLogger():
         queueLogger = log.getQueueLogger()
         queueLogger.terminate()

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -26,6 +26,7 @@ import rhsm.connection as rhsm_connection
 import rhsm.certificate as rhsm_certificate
 import rhsm.config as rhsm_config
 
+from virtwho.config import NotSetSentinel
 from virtwho.manager import Manager, ManagerError, ManagerFatalError, ManagerThrottleError
 from virtwho.virt import AbstractVirtReport
 
@@ -56,13 +57,14 @@ class SubscriptionManager(Manager):
         self.logger = logger
         self.options = options
         self.cert_uuid = None
-
-        self.rhsm_config = rhsm_config.initConfig(rhsm_config.DEFAULT_CONFIG_PATH)
+        self.rhsm_config = None
         self.readConfig()
 
     def readConfig(self):
         """ Parse rhsm.conf in order to obtain consumer
             certificate and key paths. """
+        self.rhsm_config = rhsm_config.initConfig(
+            rhsm_config.DEFAULT_CONFIG_PATH)
         consumerCertDir = self.rhsm_config.get("rhsm", "consumerCertDir")
         cert = 'cert.pem'
         key = 'key.pem'
@@ -82,39 +84,43 @@ class SubscriptionManager(Manager):
             'proxy_password': self.rhsm_config.get('server', 'proxy_password'),
             'insecure': self.rhsm_config.get('server', 'insecure')
         }
+        kwargs_to_config = {
+            'host': 'rhsm_hostname',
+            'ssl_port': 'rhsm_port',
+            'handler': 'rhsm_prefix',
+            'proxy_hostname': 'rhsm_proxy_hostname',
+            'proxy_port': 'rhsm_proxy_port',
+            'proxy_user': 'rhsm_proxy_user',
+            'proxy_password': 'rhsm_proxy_password',
+            'insecure': 'rhsm_insecure'
+        }
 
         rhsm_username = None
         rhsm_password = None
 
         if config:
-            rhsm_username = config.rhsm_username
-            rhsm_password = config.rhsm_password
+            try:
+                rhsm_username = config['rhsm_username']
+                rhsm_password = config['rhsm_password']
+            except KeyError:
+                pass
+
+            if rhsm_username == NotSetSentinel:
+                rhsm_username = None
+            if rhsm_password == NotSetSentinel:
+                rhsm_password = None
 
             # Testing for None is necessary, it might be an empty string
-
-            if config.rhsm_hostname is not None:
-                kwargs['host'] = config.rhsm_hostname
-
-            if config.rhsm_port is not None:
-                kwargs['ssl_port'] = int(config.rhsm_port)
-
-            if config.rhsm_prefix is not None:
-                kwargs['handler'] = config.rhsm_prefix
-
-            if config.rhsm_proxy_hostname is not None:
-                kwargs['proxy_hostname'] = config.rhsm_proxy_hostname
-
-            if config.rhsm_proxy_port is not None:
-                kwargs['proxy_port'] = config.rhsm_proxy_port
-
-            if config.rhsm_proxy_user is not None:
-                kwargs['proxy_user'] = config.rhsm_proxy_user
-
-            if config.rhsm_proxy_password is not None:
-                kwargs['proxy_password'] = config.rhsm_proxy_password
-
-            if config.rhsm_insecure is not None:
-                kwargs['insecure'] = config.rhsm_insecure
+            for key, value in kwargs.iteritems():
+                try:
+                    from_config = config[kwargs_to_config[key]]
+                    if from_config is not NotSetSentinel and from_config is \
+                            not None:
+                        if key is 'ssl_port':
+                            from_config = int(from_config)
+                        kwargs[key] = from_config
+                except KeyError:
+                    continue
 
         if rhsm_username and rhsm_password:
             self.logger.debug("Authenticating with RHSM username %s", rhsm_username)

--- a/virtwho/virt/__init__.py
+++ b/virtwho/virt/__init__.py
@@ -2,8 +2,9 @@
 
 from virt import (Virt, VirtError, Guest, AbstractVirtReport, DomainListReport,
                   HostGuestAssociationReport, ErrorReport,
-                  Hypervisor, DestinationThread)
+                  Hypervisor, DestinationThread, IntervalThread, info_to_destination_class)
 
 __all__ = ['Virt', 'VirtError', 'Guest', 'AbstractVirtReport',
            'DomainListReport', 'HostGuestAssociationReport',
-           'ErrorReport', 'Hypervisor', 'DestinationThread']
+           'ErrorReport', 'Hypervisor', 'DestinationThread',
+           'IntervalThread', 'info_to_destination_class']

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -496,21 +496,30 @@ if __name__ == '__main__':  # pragma: no cover
     logger = logging.getLogger('virtwho.esx')
     logger.addHandler(logging.StreamHandler())
     from virtwho.config import Config
+    from virtwho.datastore import Datastore
+    from threading import Thread, Event
     config = Config('esx', 'esx', server=sys.argv[1], username=sys.argv[2],
                     password=sys.argv[3])
-    vsphere = Esx(logger, config)
-    from Queue import Queue
-    from threading import Event, Thread
-    q = Queue()
+    datastore = Datastore()
+    vsphere = Esx(logger, config, datastore)
+    printer_terminate_event = Event()
 
     class Printer(Thread):
         def run(self):
-            while True:
-                print(q.get(True).association)
+            last_hash = None
+            while not printer_terminate_event.is_set():
+                try:
+                    report = datastore.get(config.name)
+                    if report and report.hash != last_hash:
+                        print(report.association)
+                        last_hash = report.hash
+                except KeyError:
+                    pass
     p = Printer()
-    p.daemon = True
     p.start()
     try:
-        vsphere.start_sync(q, Event())
+        vsphere.start_sync()
     except KeyboardInterrupt:
+        printer_terminate_event.set()
+        p.join()
         sys.exit(1)

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -74,7 +74,7 @@ class Libvirtd(Virt):
     CONFIG_TYPE = "libvirt"
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False ,registerEvents=True):
+                 interval=None, oneshot=False, registerEvents=True):
         super(Libvirtd, self).__init__(logger, config, dest,
                                        terminate_event=terminate_event,
                                        interval=interval,

--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -210,19 +210,30 @@ if __name__ == "__main__":  # pragma: no cover
     logger.addHandler(logging.StreamHandler())
     url, username, password = sys.argv[1:4]
     config = Config('xen', 'xen', server=url, username=username, password=password)
-    xenserver = Xen(logger, config)
-    from Queue import Queue
+    from virtwho.datastore import Datastore
     from threading import Event, Thread
-    q = Queue()
+    printer_terminate_event = Event()
+    datastore = Datastore()
+
+    xenserver = Xen(logger, config, datastore)
 
     class Printer(Thread):
         def run(self):
-            while True:
-                print q.get(True).association
+            last_hash = None
+            while not printer_terminate_event.is_set():
+                try:
+                    report = datastore.get(config.name)
+                    if report and report.hash != last_hash:
+                        print report.association
+                        last_hash = report.hash
+                except KeyError:
+                    pass
     p = Printer()
     p.daemon = True
     p.start()
     try:
-        xenserver.start_sync(q, Event())
+        xenserver.start_sync()
     except KeyboardInterrupt:
+        printer_terminate_event.set()
+        p.join()
         sys.exit(1)


### PR DESCRIPTION
This PR modifies and utilizes the other building blocks from the other interval_* PRs to actually start using destination threads as per the design.

Note that this branch represents the minimum viable implementation (from my perspective) of the interval design and that much of what is contained herein will be changed in future work on virt-who configuration.

The ways to test this are numerous. I would suggest running this branch from source with different test configurations and options as you normally would with virt-who prior to the interval design and looking for any difference in functionality. The primary expected difference is that virt-who will now send all reports on the interval for each owner/env (for satellite 6 / hosted) and each configured satellite 5 instance per interval. In the case of hypervisor checkins for satellite 6 reports are now batched into one API call (one larger check in).


Post review: I will squash the many commits into something more reasonable and add a more useful summary of changes as the commit message for the single commit.