### PR TITLE
1436811: Send reports on the interval per destination

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -322,8 +322,8 @@ type=esx
                 **TestReadingConfigs.dest_options_2)
 
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]
         }
 
         manager = ConfigManager(self.logger, self.config_dir)
@@ -352,8 +352,8 @@ type=esx
         expected_dest = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_1)
 
-        expected_mapping = {expected_dest: set([config_1['name'],
-                                                config_2['name']])}
+        expected_mapping = {expected_dest: [config_1['name'],
+                                            config_2['name']]}
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
@@ -387,8 +387,8 @@ type=esx
         expected_dest_2 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_2)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])  # config_2['name'] ==
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]  # config_2['name'] ==
                                                  # config_1['name']
         }
 
@@ -405,7 +405,7 @@ type=esx
         expected_dest_1 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_1)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']])
+            expected_dest_1: [config_1['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -424,8 +424,8 @@ type=esx
         expected_dest_2 = Satellite6DestinationInfo(
                 **TestReadingConfigs.dest_options_2)
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -464,9 +464,9 @@ type=esx
         expected_dest_3 = Satellite6DestinationInfo(**dest_options_3)
 
         expected_mapping = {
-            expected_dest_1: set([config_1['name']]),
-            expected_dest_2: set([config_2['name'], config_3['name']]),
-            expected_dest_3: set([config_4['name']])
+            expected_dest_1: [config_1['name']],
+            expected_dest_2: [config_2['name'], config_3['name']],
+            expected_dest_3: [config_4['name']]
         }
 
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -477,7 +477,6 @@ type=esx
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
-
 
     def testLibvirtConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,45 +30,115 @@ import random
 
 from base import TestBase, unittest
 
-from virtwho.config import ConfigManager, InvalidOption, GeneralConfig, NotSetSentinel, GlobalConfig, parse_list
+from virtwho.config import ConfigManager, InvalidOption, GeneralConfig, \
+    NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo
 from virtwho.password import Password, InvalidKeyFile
+
+default_config_values = {
+    "name":"test",
+    "type": "esx",
+    "server": "1.2.3.4",
+    "username": "admin",
+    "password": "password",
+    "owner": "root",
+    "env": "staging",
+    "rhsm_username": "admin",
+    "rhsm_password": "password",
+    "rhsm_hostname": "host",
+    "rhsm_port": "1234",
+    "rhsm_prefix": "prefix",
+    "rhsm_proxy_hostname": "proxy host",
+    "rhsm_proxy_port": "4321",
+    "rhsm_proxy_user": "proxyuser",
+    "rhsm_proxy_password": "proxypass",
+    "rhsm_insecure": "1"
+}
+
+
+def combine_dicts(*args):
+    """
+    A utility method to combine all dictionaries passed into one
+    @param args: One or more dicts
+    @type args: dict
+
+    @return: dict with the combined values from all args. NOTE: The value
+    for any key in more than one dict will be the value of the last dict
+    in the arg list that has that key.
+    @rtype: dict
+    """
+    result = {}
+    for arg in args:
+        result.update(arg)
+    return result
+
+
+def append_number_to_all(in_dict, number):
+    result = {}
+    for key, value in in_dict.iteritems():
+        result[key] = value + str(number)
+    return result
 
 
 class TestReadingConfigs(TestBase):
+    source_options_1 = {
+        "name": "test1",
+        "type": "esx",
+        "server": "1.2.3.4",
+        "username": "admin",
+        "password": "password",
+    }
+    source_options_2 = {
+        "name": "test2",
+        "type": "hyperv",
+        "server": "1.2.3.5",
+        "username": "admin",
+        "password": "password",
+    }
+    dest_options = {
+        "owner": "root",
+        "env": "staging",
+        "rhsm_username": "rhsm_admin",
+        "rhsm_password": "rhsm_password",
+        "rhsm_hostname": "host",
+        "rhsm_port": "1234",
+        "rhsm_prefix": "prefix",
+        "rhsm_proxy_hostname": "proxyhost",
+        "rhsm_proxy_port": "4321",
+        "rhsm_proxy_user": "proxyuser",
+        "rhsm_proxy_password": "proxypass",
+        "rhsm_insecure": ""
+    }
+    dest_options_1 = append_number_to_all(dest_options, 1)
+    dest_options_2 = append_number_to_all(dest_options, 2)
+
     def setUp(self):
         self.config_dir = mkdtemp()
         self.addCleanup(shutil.rmtree, self.config_dir)
         self.logger = logging.getLogger("virtwho.main")
 
+    @staticmethod
+    def dict_to_ini(in_dict):
+        """
+        A utility method that formats the given dict as a section of an ini
+
+        @param in_dict: The dictionary containing the keys and values to be
+        made ini-like. The section name returned by this method will be the
+        value of the "name" key in this dict.
+        @type in_dict: dict
+
+        @return: A string formatted like an ini file section
+        @rtype: str
+        """
+        header = "[%s]\n" % in_dict.get("name", "test")
+        body = "\n".join(["%s=%s" % (key, val) for key, val in
+                          in_dict.iteritems() if key is not "name"])
+        return header + body + "\n"
+
     def testEmptyConfig(self):
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEqual(len(manager.configs), 0)
 
-    def testBasicConfig(self):
-        with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
-            f.write("""
-[test]
-type=esx
-server=1.2.3.4
-username=admin
-password=password
-owner=root
-env=staging
-rhsm_username=admin
-rhsm_password=password
-rhsm_hostname=host
-rhsm_port=1234
-rhsm_prefix=prefix
-rhsm_proxy_hostname=proxy host
-rhsm_proxy_port=4321
-rhsm_proxy_user=proxyuser
-rhsm_proxy_password=proxypass
-rhsm_insecure=1
-""")
-
-        manager = ConfigManager(self.logger, self.config_dir)
-        self.assertEqual(len(manager.configs), 1)
-        config = manager.configs[0]
+    def assertConfigEqualsDefault(self, config):
         self.assertEqual(config.name, "test")
         self.assertEqual(config.type, "esx")
         self.assertEqual(config.server, "1.2.3.4")
@@ -87,6 +157,20 @@ rhsm_insecure=1
         self.assertEqual(config.rhsm_proxy_password, 'proxypass')
         self.assertEqual(config.rhsm_insecure, '1')
         self.assertEqual(config.simplified_vim, True)
+
+    def assert_config_contains_all(self, config, options):
+        for key in options:
+            config_value = getattr(config, key)
+            self.assertEquals(config_value, options[key])
+
+    def testBasicConfig(self):
+        with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(default_config_values))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEqual(len(manager.configs), 1)
+        config = manager.configs[0]
+        self.assertConfigEqualsDefault(config)
 
     def testInvalidConfig(self):
         with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
@@ -205,170 +289,195 @@ type=esx
         self.assertRaises(InvalidOption, ConfigManager, self.logger, self.config_dir)
 
     def testMultipleConfigsInFile(self):
-        with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
-            f.write("""
-[test1]
-type=esx
-server=1.2.3.4
-username=admin
-password=password
-owner=root1
-env=staging1
-rhsm_username=rhsm_admin1
-rhsm_password=rhsm_password1
-rhsm_hostname=host1
-rhsm_port=12341
-rhsm_prefix=prefix1
-rhsm_proxy_hostname=proxyhost1
-rhsm_proxy_port=43211
-rhsm_proxy_user=proxyuser1
-rhsm_proxy_password=proxypass1
-rhsm_insecure=1
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        config_2 = combine_dicts(TestReadingConfigs.source_options_2,
+                                 TestReadingConfigs.dest_options_2)
 
-[test2]
-type=hyperv
-server=1.2.3.5
-username=admin
-password=password
-owner=root2
-env=staging2
-rhsm_username=rhsm_admin2
-rhsm_password=rhsm_password2
-rhsm_hostname=host2
-rhsm_port=12342
-rhsm_prefix=prefix2
-rhsm_proxy_hostname=proxyhost2
-rhsm_proxy_port=43212
-rhsm_proxy_user=proxyuser2
-rhsm_proxy_password=proxypass2
-rhsm_insecure=2
-""")
+        with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1) +
+                    TestReadingConfigs.dict_to_ini(config_2))
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEqual(len(manager.configs), 2)
         config = manager.configs[0]
-        self.assertEqual(config.name, "test1")
-        self.assertEqual(config.type, "esx")
-        self.assertEqual(config.server, "1.2.3.4")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root1")
-        self.assertEqual(config.env, "staging1")
-        self.assertEqual(config.rhsm_username, 'rhsm_admin1')
-        self.assertEqual(config.rhsm_password, 'rhsm_password1')
-        self.assertEqual(config.rhsm_hostname, 'host1')
-        self.assertEqual(config.rhsm_port, '12341')
-        self.assertEqual(config.rhsm_prefix, 'prefix1')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost1')
-        self.assertEqual(config.rhsm_proxy_port, '43211')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser1')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass1')
-        self.assertEqual(config.rhsm_insecure, '1')
+        self.assert_config_contains_all(config, config_1)
         config = manager.configs[1]
-        self.assertEqual(config.name, "test2")
-        self.assertEqual(config.type, "hyperv")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.server, "1.2.3.5")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root2")
-        self.assertEqual(config.env, "staging2")
-        self.assertEqual(config.rhsm_username, 'rhsm_admin2')
-        self.assertEqual(config.rhsm_password, 'rhsm_password2')
-        self.assertEqual(config.rhsm_hostname, 'host2')
-        self.assertEqual(config.rhsm_port, '12342')
-        self.assertEqual(config.rhsm_prefix, 'prefix2')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost2')
-        self.assertEqual(config.rhsm_proxy_port, '43212')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser2')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass2')
-        self.assertEqual(config.rhsm_insecure, '2')
+        self.assert_config_contains_all(config, config_2)
 
     def testMultipleConfigFiles(self):
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        config_2 = combine_dicts(TestReadingConfigs.source_options_2,
+                                 TestReadingConfigs.dest_options_2)
+
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
-            f.write("""
-[test1]
-type=esx
-server=1.2.3.4
-username=admin
-password=password
-owner=root
-env=staging
-rhsm_username=rhsm_admin1
-rhsm_password=rhsm_password1
-rhsm_hostname=host1
-rhsm_port=12341
-rhsm_prefix=prefix1
-rhsm_proxy_hostname=proxyhost1
-rhsm_proxy_port=43211
-rhsm_proxy_user=proxyuser1
-rhsm_proxy_password=proxypass1
-rhsm_insecure=1
-""")
+            f.write(TestReadingConfigs.dict_to_ini(config_1))
         with open(os.path.join(self.config_dir, "test2.conf"), "w") as f:
-            f.write("""
-[test2]
-type=hyperv
-server=1.2.3.5
-username=admin
-password=password
-owner=root
-env=staging
-rhsm_username=rhsm_admin2
-rhsm_password=rhsm_password2
-rhsm_hostname=host2
-rhsm_port=12342
-rhsm_prefix=prefix2
-rhsm_proxy_hostname=proxyhost2
-rhsm_proxy_port=43212
-rhsm_proxy_user=proxyuser2
-rhsm_proxy_password=proxypass2
-rhsm_insecure=2
-""")
+            f.write(TestReadingConfigs.dict_to_ini(config_2))
+
+        expected_dest_1 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+        expected_dest_2 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_2)
+
+        expected_mapping = {
+            expected_dest_1: set([config_1['name']]),
+            expected_dest_2: set([config_2['name']])
+        }
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEqual(len(manager.configs), 2)
+        self.assertEqual(manager.dest_to_sources_map, expected_mapping)
+        self.assertEqual(manager.dests, set([expected_dest_1, expected_dest_2]))
+        self.assertEqual(manager.sources,
+                         set([config_1['name'], config_2['name']]))
 
-        config2, config1 = manager.configs
+        result2, result1 = manager.configs
 
-        self.assertIn(config1.name, ("test1", "test2"))
-        if config1.name == "test2":
-            config2, config1 = config1, config2
+        self.assertIn(result1.name, ("test1", "test2"))
+        if result1.name == "test2":
+            result2, result1 = result1, result2
 
-        self.assertEqual(config1.name, "test1")
-        self.assertEqual(config1.type, "esx")
-        self.assertEqual(config1.server, "1.2.3.4")
-        self.assertEqual(config1.username, "admin")
-        self.assertEqual(config1.password, "password")
-        self.assertEqual(config1.owner, "root")
-        self.assertEqual(config1.env, "staging")
-        self.assertEqual(config1.rhsm_username, 'rhsm_admin1')
-        self.assertEqual(config1.rhsm_password, 'rhsm_password1')
-        self.assertEqual(config1.rhsm_hostname, 'host1')
-        self.assertEqual(config1.rhsm_port, '12341')
-        self.assertEqual(config1.rhsm_prefix, 'prefix1')
-        self.assertEqual(config1.rhsm_proxy_hostname, 'proxyhost1')
-        self.assertEqual(config1.rhsm_proxy_port, '43211')
-        self.assertEqual(config1.rhsm_proxy_user, 'proxyuser1')
-        self.assertEqual(config1.rhsm_proxy_password, 'proxypass1')
-        self.assertEqual(config1.rhsm_insecure, '1')
+        self.assert_config_contains_all(result1, config_1)
+        self.assert_config_contains_all(result2, config_2)
 
-        self.assertEqual(config2.name, "test2")
-        self.assertEqual(config2.type, "hyperv")
-        self.assertEqual(config2.server, "1.2.3.5")
-        self.assertEqual(config2.username, "admin")
-        self.assertEqual(config2.password, "password")
-        self.assertEqual(config2.owner, "root")
-        self.assertEqual(config2.env, "staging")
-        self.assertEqual(config2.rhsm_username, 'rhsm_admin2')
-        self.assertEqual(config2.rhsm_password, 'rhsm_password2')
-        self.assertEqual(config2.rhsm_hostname, 'host2')
-        self.assertEqual(config2.rhsm_port, '12342')
-        self.assertEqual(config2.rhsm_prefix, 'prefix2')
-        self.assertEqual(config2.rhsm_proxy_hostname, 'proxyhost2')
-        self.assertEqual(config2.rhsm_proxy_port, '43212')
-        self.assertEqual(config2.rhsm_proxy_user, 'proxyuser2')
-        self.assertEqual(config2.rhsm_proxy_password, 'proxypass2')
-        self.assertEqual(config2.rhsm_insecure, '2')
+    def test_many_sources_to_one_dest(self):
+        # This tests that there can be multiple configs that specify to
+        # report to the same destination
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        config_2 = combine_dicts(TestReadingConfigs.source_options_2,
+                                 TestReadingConfigs.dest_options_1)
+        expected_dest = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+
+        expected_mapping = {expected_dest: set([config_1['name'],
+                                                config_2['name']])}
+
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1) +
+                    TestReadingConfigs.dict_to_ini(config_2))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEqual(manager.dests, set([expected_dest]))
+        self.assertEqual(manager.sources,
+                         set([config_1['name'], config_2['name']]))
+
+        self.assertEquals(manager.dest_to_sources_map, expected_mapping)
+
+    def test_one_source_to_many_dests(self):
+        # This tests that there can be one source that specifies
+        # information for different destinations and that the correct mapping
+        # is created.
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+
+        # NOTE: virt-who today does not support config sections having the same
+        # name. Hence the only way to have one source go to multiple
+        # destinations (without new config options) is to have two sections
+        # with the same information but different section names
+        config_options_2 = TestReadingConfigs.source_options_1.copy()
+        config_options_2['name'] = 'test2'
+        config_2 = combine_dicts(config_options_2,
+                                 TestReadingConfigs.dest_options_2)
+
+        expected_dest_1 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+        expected_dest_2 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_2)
+        expected_mapping = {
+            expected_dest_1: set([config_1['name']]),
+            expected_dest_2: set([config_2['name']])  # config_2['name'] ==
+                                                 # config_1['name']
+        }
+
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1) +
+                    TestReadingConfigs.dict_to_ini(config_2))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEquals(manager.dest_to_sources_map, expected_mapping)
+
+    def test_one_source_to_one_dest(self):
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        expected_dest_1 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+        expected_mapping = {
+            expected_dest_1: set([config_1['name']])
+        }
+
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEquals(manager.dest_to_sources_map, expected_mapping)
+
+    def test_two_sources_to_two_dests(self):
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        config_2 = combine_dicts(TestReadingConfigs.source_options_2,
+                                 TestReadingConfigs.dest_options_2)
+        expected_dest_1 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+        expected_dest_2 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_2)
+        expected_mapping = {
+            expected_dest_1: set([config_1['name']]),
+            expected_dest_2: set([config_2['name']])
+        }
+
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1) +
+                    TestReadingConfigs.dict_to_ini(config_2))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEquals(manager.dest_to_sources_map, expected_mapping)
+
+    def test_many_sources_to_many_dests(self):
+        config_1 = combine_dicts(TestReadingConfigs.source_options_1,
+                                 TestReadingConfigs.dest_options_1)
+        config_2 = combine_dicts(TestReadingConfigs.source_options_2,
+                                 TestReadingConfigs.dest_options_2)
+
+        # Create another source config that is slightly different
+        source_3_options = TestReadingConfigs.source_options_2.copy()
+        source_3_options['name'] = 'test3'
+        source_4_options = TestReadingConfigs.source_options_1.copy()
+        source_4_options['name'] = 'test4'
+
+        # Create another dest config that is slightly different
+        dest_options_3 = TestReadingConfigs.dest_options_2.copy()
+        dest_options_3['owner'] = 'some_cool_owner_person'
+
+        config_3 = combine_dicts(source_3_options,
+                                 TestReadingConfigs.dest_options_2)
+
+        config_4 = combine_dicts(source_4_options,
+                                 dest_options_3)
+
+        expected_dest_1 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_1)
+        expected_dest_2 = Satellite6DestinationInfo(
+                **TestReadingConfigs.dest_options_2)
+        expected_dest_3 = Satellite6DestinationInfo(**dest_options_3)
+
+        expected_mapping = {
+            expected_dest_1: set([config_1['name']]),
+            expected_dest_2: set([config_2['name'], config_3['name']]),
+            expected_dest_3: set([config_4['name']])
+        }
+
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write(TestReadingConfigs.dict_to_ini(config_1) +
+                    TestReadingConfigs.dict_to_ini(config_2) +
+                    TestReadingConfigs.dict_to_ini(config_3) +
+                    TestReadingConfigs.dict_to_ini(config_4))
+
+        manager = ConfigManager(self.logger, self.config_dir)
+        self.assertEquals(manager.dest_to_sources_map, expected_mapping)
+
 
     def testLibvirtConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,0 +1,140 @@
+from base import TestBase
+from mock import sentinel, patch, MagicMock
+from threading import Lock
+from virtwho.datastore import Datastore
+
+
+class TestDatastore(TestBase):
+
+    def setUp(self):
+        pickle_patcher = patch('virtwho.datastore.pickle')
+        self.mock_pickle = pickle_patcher.start()
+        self.mock_pickle.dumps.return_value = sentinel.pickled_value
+        self.mock_pickle.loads.return_value = sentinel.unpickled_value
+        self.addCleanup(pickle_patcher.stop)
+
+        lock_patcher = patch('virtwho.datastore.Lock')
+        mock_lock_class = lock_patcher.start()
+        mock_lock_instance = MagicMock(spec=Lock())
+        mock_lock_class.return_value = mock_lock_instance
+        self.mock_lock = mock_lock_instance
+        self.addCleanup(lock_patcher.stop)
+
+    def mock_test_data(self, datastore, **kwargs):
+        # Sets the datastore to contain the keys and values of the kwargs
+        # in a way that does not use the put method of the datastore
+        # Returns the datastore instance as modified, the test internal
+        # datastore
+        mock_internal_datastore = MagicMock(wraps=dict(kwargs))
+        datastore._datastore = mock_internal_datastore
+        return datastore, mock_internal_datastore
+
+    def test_get_uses_lock(self):
+        # Ensure a lock is acquired before returning a particular entry in the
+        # store
+
+        # Ensure that a lock is acquired before updating a particular entry
+        # in the store.
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+                                                                 test_item=sentinel.test_value)
+
+        def assert_internal_store_unchanged(*args, **kwargs):
+            # Assert there have been no accesses of the internal datastore
+            mock_internal_datastore.__getitem__.assert_not_called()
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        def assert_internal_store_accessed(*args, **kwargs):
+            mock_internal_datastore.__getitem__.assert_called_once_with(
+                    "test_item")
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        self.mock_lock.__enter__.side_effect = assert_internal_store_unchanged
+        self.mock_lock.__exit__.side_effect = assert_internal_store_accessed
+
+        datastore.get("test_item")
+
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        self.mock_lock.__enter__.assert_called_once()
+        self.mock_lock.__exit__.assert_called_once()
+
+    def test_get_nonexistant_item_raises_keyerror(self):
+        datastore = Datastore()
+        item = sentinel.no_value
+        try:
+            item = datastore.get("NONEXISTANT")
+        except KeyError:
+            return
+        self.fail("Item retrieved for nonexistant key: %s" % item)
+
+    def test_get_nonexistant_item_with_default_returns_default(self):
+        # Ensures the default is returned if there is one provided and the
+        # key does not exist
+        datastore = Datastore()
+        result = datastore.get("NONEXISTANT", default=sentinel.default_value)
+        self.assertTrue(result == sentinel.default_value)
+
+    def test_get_existing_item_with_default_returns_item(self):
+        # Ensures the item is returned if there is a default provided,
+        # and the item exists
+        datastore = Datastore()
+        expected_value = sentinel.test_value
+        self.mock_pickle.loads.side_effect = lambda x: x
+        with patch.dict(datastore._datastore, test_item=expected_value):
+            result = datastore.get("test_item", default=sentinel.default_value)
+            self.assertEquals(result, expected_value)
+
+    def test_get_returns_correct_item(self):
+        # Ensure that calling the get method returns the right value for a
+        # particular key, and that the value is loaded using pickle
+
+        datastore = Datastore()
+        with patch.dict(datastore._datastore,
+                        test_item=sentinel.test_item_value):
+            result = datastore.get("test_item")
+        self.mock_pickle.loads.assert_called_with(sentinel.test_item_value)
+        self.assertEquals(result, self.mock_pickle.loads.return_value)
+
+    def test_put_locking(self):
+        # Ensure that a lock is acquired before (and released after) updating a
+        # particular entry in the store.
+        # These assertions assume the lock is used as a context manager
+        # and that the lock (when used as a context manager) is acquired by
+        # the calling thread on __enter__ and released by the calling thread
+        # on __exit__
+        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+                                                                 test_item=sentinel.test_value)
+
+        def assert_internal_store_unchanged(*args, **kwargs):
+            # Assert there have been no accesses of the internal datastore
+            mock_internal_datastore.__getitem__.assert_not_called()
+            mock_internal_datastore.__setitem__.assert_not_called()
+
+        def assert_internal_store_accessed(*args, **kwargs):
+            mock_internal_datastore.__setitem__.assert_called_once_with(
+                    "test_item", self.mock_pickle.dumps.return_value)
+
+        self.mock_lock.__enter__.side_effect = assert_internal_store_unchanged
+        self.mock_lock.__exit__.side_effect = assert_internal_store_accessed
+
+        datastore.put("test_item", "test_item")
+        self.mock_lock.__enter__.assert_called_once()
+        self.mock_lock.__exit__.assert_called_once()
+
+    def test_put_uses_pickle_dumps(self):
+        # Ensure that put uses the return value of pickle.dumps
+        test_item = "test_value"
+        test_key = "test_item"
+        datastore, mock_internal_ds = self.mock_test_data(Datastore(),
+                                                          test_item=test_item)
+        datastore.put(test_key, test_item)
+        self.mock_pickle.dumps.assert_called_with(test_item)
+        expected_value = self.mock_pickle.dumps.return_value
+        mock_internal_ds.__setitem__.assert_called_with(test_key,
+                                                        expected_value)

--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -35,12 +35,14 @@ class TestEsx(TestBase):
     def setUp(self):
         config = Config('test', 'esx', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.esx = Esx(self.logger, config)
+        self.esx = Esx(self.logger, config, None)  #  No dest given here
 
     def run_once(self, queue=None):
         ''' Run ESX in oneshot mode '''
         self.esx._oneshot = True
-        self.esx._queue = queue or Queue()
+        if queue is None:
+            queue = Mock(spec=Queue())
+        self.esx.dest = queue
         self.esx._terminate_event = Event()
         self.esx._oneshot = True
         self.esx._interval = 0

--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -21,7 +21,8 @@ import os
 import requests
 import suds
 from mock import patch, ANY, MagicMock, Mock
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from virtwho.config import Config

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -91,7 +91,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         mapping = virt.getHostGuestMapping()
         self.assertTrue("hypervisors" in mapping)
@@ -119,7 +119,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         self.assertRaises(VirtError, virt.getHostGuestMapping)
 
@@ -137,7 +137,7 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         guests = virt.listDomains()
         self.assertEquals(len(guests), 1)
@@ -159,6 +159,6 @@ file=%s
 
         manager = ConfigManager(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.fromConfig(self.logger, manager.configs[0])
+        virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
         self.assertRaises(VirtError, virt.listDomains)

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -138,12 +138,12 @@ class TestHyperV(TestBase):
     def setUp(self):
         config = Config('test', 'hyperv', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.hyperv = HyperV(self.logger, config)
+        self.hyperv = HyperV(self.logger, config, None)
 
     def run_once(self, queue=None):
         ''' Run Hyper-V in oneshot mode '''
         self.hyperv._oneshot = True
-        self.hyperv._queue = queue or Queue()
+        self.hyperv.dest = queue or Queue()
         self.hyperv._terminate_event = Event()
         self.hyperv._interval = 0
         self.hyperv._run()

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -20,7 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
 from mock import patch, MagicMock, ANY
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 import requests
 
 from base import TestBase

--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -41,8 +41,7 @@ class TestLibvirtd(TestBase):
         pass
 
     def run_virt(self, config, in_queue=None):
-        v = Virt.fromConfig(self.logger, config)
-        v._queue = in_queue or Queue()
+        v = Virt.from_config(self.logger, config, in_queue or Queue())
         v._terminate_event = Event()
         v._interval = 3600
         v._oneshot = True

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """
 from mock import patch, Mock, sentinel
 import threading
-from multiprocessing import Queue
+from Queue import Queue
 
 from base import TestBase
 
@@ -128,7 +128,7 @@ class TestLog(TestBase):
 
 class TestQueueLogger(TestBase):
 
-    @patch('multiprocessing.queues.Queue')
+    @patch('virtwho.log.Queue')
     @patch('logging.getLogger')
     def test_queue_logger(self, getLogger, queue):
         fake_queue = sentinel.queue

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -94,14 +94,14 @@ class TestRhevM(TestBase):
         config = Config('test', 'rhevm', server='localhost', username='username',
                         password='password', owner='owner', env='env')
 
-        self.rhevm = RhevM(self.logger, config)
+        self.rhevm = RhevM(self.logger, config, None)
         self.rhevm.major_version = '3'
         self.rhevm.build_urls()
 
     def run_once(self, queue=None):
         ''' Run RHEV-M in oneshot mode '''
         self.rhevm._oneshot = True
-        self.rhevm._queue = queue or Queue()
+        self.rhevm.dest = queue or Queue()
         self.rhevm._terminate_event = Event()
         self.rhevm._oneshot = True
         self.rhevm._interval = 0

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -21,7 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import os
 import requests
 from mock import patch, call, ANY, MagicMock
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from proxy import Proxy

--- a/tests/test_vdsm.py
+++ b/tests/test_vdsm.py
@@ -33,7 +33,7 @@ class TestVdsm(TestBase):
         def fakeSecureConnect(self):
             return MagicMock()
         Vdsm._secureConnect = fakeSecureConnect
-        self.vdsm = Vdsm(self.logger, config)
+        self.vdsm = Vdsm(self.logger, config, None)
         self.vdsm.prepare()
 
     def test_connect(self):

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -5,8 +5,13 @@ import shutil
 
 from base import TestBase
 
-from virtwho.config import ConfigManager
-from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest
+from mock import Mock, patch, call
+from threading import Event
+
+from virtwho.config import ConfigManager, Config
+from virtwho.manager import ManagerThrottleError
+from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
+    DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
 
 
 xvirt = type("", (), {'CONFIG_TYPE': 'xxx'})()
@@ -83,3 +88,354 @@ env=env
                 included_hypervisor
             ]
         }
+
+
+class TestDestinationThread(TestBase):
+    def test_get_data(self):
+        # Show that get_data accesses the given source and tries to retrieve
+        # the right source_keys
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        result_data = destination_thread._get_data()
+        self.assertEquals(result_data, datastore)
+
+    def test_get_data_ignore_same_reports(self):
+        # Show that the data returned from _get_data does not include those
+        # reports whose hash is identical to that of the last one sent for
+        # the given source
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        last_report_for_source = {
+            'source1': report1.hash
+        }
+        expected_data = {
+            'source2': report2
+        }
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.last_report_for_source = last_report_for_source
+        result_data = destination_thread._get_data()
+        self.assertEquals(result_data, expected_data)
+
+    @patch('virtwho.virt.virt.Event')
+    def test_send_data_quit_on_error_report(self, mock_event_class):
+        mock_event = Mock(spec=Event())
+        mock_event_class.return_value = mock_event
+
+        mock_error_report = Mock(spec=ErrorReport)
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread._send_data(mock_error_report)
+        mock_event.set.assert_called()
+
+    def test_send_data_batch_hypervisor_checkin(self):
+        # This tests that reports of the right type are batched into one
+        # and that the hypervisorCheckIn method of the destination is called
+        # with the right parameters
+        config1 = Config('source1', 'esx')
+        config1.exclude_hosts = []
+        config1.filter_hosts = []
+
+        config2 = Config('source2', 'esx')
+        config2.exclude_hosts = []
+        config2.filter_hosts = []
+
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+
+        def check_hypervisorCheckIn(report, options=None):
+            self.assertEquals(report.association['hypervisors'],
+                              data_to_send.values)
+
+        manager.hypervisorCheckIn = Mock(side_effect=check_hypervisorCheckIn)
+        logger = Mock()
+        config = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread._send_data(data_to_send)
+
+    def test_send_data_poll_hypervisor_async_result(self):
+        # This test's that when we have an async result from the server,
+        # we poll for the result
+
+        # Setup the test data
+        config1 = Config('source1', 'esx')
+        config2 = Config('source2', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+        source_keys = ['source1', 'source2']
+        batch_report1 = Mock()  # The "report" to return from hypervisorCheckIn
+        batch_report1.state = AbstractVirtReport.STATE_CREATED
+        datastore = {'source1': report1, 'source2': report2}
+        manager = Mock()
+        manager.hypervisorCheckIn.return_value = batch_report1
+
+        # A closure to allow us to have a function that "modifies" the given
+        # report in a predictable way.
+        # In this case I want to set the state of the report to STATE_FINISHED
+        # after the first try
+        def check_report_state_closure():
+            # The local variables we'd like to use to keep track of state
+            # must be in a dict (or some other mutable container) as all
+            # references in the enclosing scope in python 2.X are read-only
+            local_variables = {'count': 0}
+
+            def mock_check_report_state(report):
+                if local_variables['count'] > 0:
+                    report.state = AbstractVirtReport.STATE_FINISHED
+                else:
+                    report.state = AbstractVirtReport.STATE_CREATED
+                    local_variables['count'] += 1
+                return report
+            return mock_check_report_state
+        check_report_mock = check_report_state_closure()
+        manager.check_report_state = Mock(side_effect=check_report_mock)
+        logger = Mock()
+        config = Mock()
+        config.polling_interval = 10
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        # In this test we want to see that the wait method is called when we
+        # expect and with what parameters we expect
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        # We expect there two be two calls to wait with the value of the
+        # polling_interval attr because we'd like to wait one polling
+        # interval before making the first check. Because the mock
+        # check_report_state function will modify the report to be in the
+        # successful state after the first call, we expect to wait exactly
+        # twice, both of duration config.polling_interval
+        destination_thread.wait.assert_has_calls([call(wait_time=config.polling_interval),
+                                                 call(wait_time=config.polling_interval)])
+
+    def test_send_data_poll_async_429(self):
+        # This test's that when a 429 is detected during async polling
+        # we wait for the amount of time specified
+        source_keys = ['source1', 'source2']
+        config1 = Config('source1', 'esx')
+        config2 = Config('source2', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
+        assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
+        report1 = HostGuestAssociationReport(config1, assoc1)
+        report2 = HostGuestAssociationReport(config2, assoc2)
+
+        datastore = {'source1': report1, 'source2': report2}
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+        config = Mock()
+        config.polling_interval = 10
+        error_to_throw = ManagerThrottleError(retry_after=20)
+
+        manager = Mock()
+        manager.hypervisorCheckIn.return_value = report1
+        # A closure to allow us to have a function that "modifies" the given
+        # report in a predictable way.
+        # In this case I want to set the state of the report to STATE_FINISHED
+        # after the first try
+
+        def check_report_state_closure(items):
+            item_iterator = iter(items)
+
+            def mock_check_report_state(report):
+                item = next(item_iterator)
+                if isinstance(item, Exception):
+                    raise item
+                report.state = item
+                return report
+            return mock_check_report_state
+        states = [error_to_throw, AbstractVirtReport.STATE_FINISHED]
+        expected_wait_calls = [call(wait_time=config.polling_interval),
+                               call(wait_time=error_to_throw.retry_after)]
+
+        check_report_mock = check_report_state_closure(states)
+        manager.check_report_state = Mock(side_effect=check_report_mock)
+        logger = Mock()
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        destination_thread.wait.assert_has_calls(expected_wait_calls)
+
+    def test_send_data_domain_list_reports(self):
+        # Show that DomainListReports are sent using the sendVirtGuests
+        # method of the destination
+
+        source_keys = ['source1']
+        config1 = Config('source1', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        report1 = DomainListReport(config1, [guest1],
+                                   hypervisor_id='hypervisor_id_1')
+
+        datastore = {'source1': report1}
+        data_to_send = {'source1': report1}
+
+        config = Mock()
+        config.polling_interval = 10
+        logger = Mock()
+
+        manager = Mock()
+        terminate_event = Mock()
+        interval = 10
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        manager.sendVirtGuests.assert_has_calls([call(report1,
+                                                      options=destination_thread.options)])
+
+    def test_send_data_429_during_send_virt_guests(self):
+        # Show that when a 429 is encountered during the sending of a
+        # DomainListReport that we retry after waiting the appropriate
+        # amount of time
+        source_keys = ['source1']
+        config1 = Config('source1', 'esx')
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+
+        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        report1 = DomainListReport(config1, [guest1],
+                                   hypervisor_id='hypervisor_id_1')
+
+        datastore = {'source1': report1}
+        data_to_send = {'source1': report1}
+
+        config = Mock()
+        config.polling_interval = 10
+        logger = Mock()
+
+        error_to_throw = ManagerThrottleError(retry_after=21)
+
+        manager = Mock()
+        manager.sendVirtGuests = Mock(side_effect=[error_to_throw, report1])
+        terminate_event = Mock()
+        interval = 10
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True)
+        destination_thread.wait = Mock()
+        destination_thread._send_data(data_to_send)
+        manager.sendVirtGuests.assert_has_calls([call(report1,
+                                                      options=destination_thread.options),
+                                                 call(report1,
+                                                      options=destination_thread.options)])
+        destination_thread.wait.assert_has_calls([call(
+                wait_time=error_to_throw.retry_after)])

--- a/tests/test_virt_intervalthread.py
+++ b/tests/test_virt_intervalthread.py
@@ -1,0 +1,186 @@
+from base import TestBase
+
+from mock import patch, Mock, sentinel, call
+from virtwho.virt import IntervalThread
+from threading import Event
+from datetime import datetime
+
+class TestIntervalThreadTiming(TestBase):
+    """
+    This is a group of tests intended to test the timing of the interval thread.
+    """
+
+    def setUp(self):
+        time_patcher = patch('time.sleep')
+        self.mock_time = time_patcher.start()
+        event_patcher = patch('virtwho.virt.virt.Event')
+        self.mock_internal_terminate_event = event_patcher.start().return_value
+        self.mock_internal_terminate_event.is_set.return_value = False
+        self.addCleanup(time_patcher.stop)
+        self.addCleanup(event_patcher.stop)
+
+        # default mock objects that can be passed into a new interval thread
+        self.config = Mock()
+        self.source = Mock()
+        self.dest = Mock()
+        self.terminate_event = Mock()
+        self.terminate_event.is_set.return_value = False
+        self.interval = 2
+        self.oneshot = True
+
+        self._get_data_return = sentinel.default_data_to_send
+        self._send_data_return = sentinel.default_send_data_return
+
+    def setup_interval_thread(self, **kwargs):
+        """
+        Sets up an interval thread class with mocks of unimplemented methods
+        to allow testing of the base implementation of those methods that have
+        concrete implementations.
+        """
+        logger = kwargs.get('logger', self.logger)
+        config = kwargs.get('config', self.config)
+        source = kwargs.get('source', self.source)
+        dest = kwargs.get('dest', self.dest)
+        terminate_event = kwargs.get('terminate_event', self.terminate_event)
+        interval = kwargs.get('interval', self.interval)
+        oneshot = kwargs.get('oneshot', self.oneshot)
+
+        interval_thread = IntervalThread(logger, config, source, dest,
+                                         terminate_event, interval, oneshot)
+
+        mock_get_data_impl = kwargs.get('mock_get_data', None)
+        if mock_get_data_impl is None:
+            mock_get_data_impl = Mock()
+            mock_get_data_impl.return_value = self._get_data_return
+
+        mock_send_data_impl = kwargs.get('mock_send_data', None)
+        if mock_send_data_impl is None:
+            mock_send_data_impl = Mock()
+            mock_send_data_impl.return_value = self._send_data_return
+
+        interval_thread._get_data = mock_get_data_impl
+        interval_thread._send_data = mock_send_data_impl
+
+        return interval_thread
+
+
+    def test__run(self):
+        """
+        Tests the timing of the _run method
+        """
+        oneshot = False
+        interval = 20  # Seconds
+        start_time = datetime(1, 1, 1, 1, 1)
+        time_taken = 10  # seconds, must be less than 60
+        end_time = datetime(start_time.year, start_time.month,
+                            start_time.day, start_time.hour, start_time.minute,
+                            start_time.second + time_taken,
+                            start_time.microsecond, start_time.tzinfo)
+        expected_wait_time = interval - time_taken
+        with patch('virtwho.virt.virt.datetime') as patcher:
+            patcher.now = Mock(side_effect=[start_time, end_time])
+            interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                         interval=interval)
+            interval_thread.is_terminated = Mock(side_effect=[False, True])
+            interval_thread.wait = Mock()
+            interval_thread._run()
+            interval_thread._get_data.assert_called()
+            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread.wait.assert_has_calls([call(expected_wait_time)])
+
+    def test__run_send_takes_longer_than_interval(self):
+        """
+        Tests the timing of the _run method
+        """
+        oneshot = False
+        interval = 20  # Seconds
+        start_time = datetime(1, 1, 1, 1, 1)
+        time_taken = 21  # seconds, must be less than 60
+        end_time = datetime(start_time.year, start_time.month,
+                            start_time.day, start_time.hour, start_time.minute,
+                            start_time.second + time_taken,
+                            start_time.microsecond, start_time.tzinfo)
+        with patch('virtwho.virt.virt.datetime') as patcher:
+            patcher.now = Mock(side_effect=[start_time, end_time])
+            interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                         interval=interval)
+            interval_thread.is_terminated = Mock(side_effect=[False, True])
+            interval_thread.wait = Mock()
+            interval_thread._run()
+            interval_thread._get_data.assert_called()
+            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread.wait.assert_not_called()
+
+
+    def test_wait(self):
+        interval_thread = self.setup_interval_thread()
+        interval_thread.is_terminated = Mock()
+        interval_thread.is_terminated.return_value = False
+        # The total time we expect to be waited
+        wait_time = 10
+        # The time we expect to be waited each interval
+        expected_wait_interval = 1
+        expected_calls = [call(expected_wait_interval) for x in range(wait_time)]
+
+        interval_thread.wait(wait_time=wait_time)
+        self.assertEquals(interval_thread.is_terminated.call_count, wait_time)
+        self.mock_time.assert_has_calls(expected_calls)
+
+    def test_is_terminated_terminate_event(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        self.terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_is_terminated_internal_terminate_event(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        self.mock_internal_terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_is_terminated_both_events(self):
+        interval_thread = self.setup_interval_thread()
+        self.assertEqual(False, interval_thread.is_terminated())
+        interval_thread._internal_terminate_event.is_set.return_value = True
+        self.terminate_event.is_set.return_value = True
+        self.assertEqual(True, interval_thread.is_terminated())
+
+    def test_stop(self):
+        interval_thread = self.setup_interval_thread()
+        interval_thread.stop()
+        self.mock_internal_terminate_event.set.assert_called()
+
+    def test_run(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, False, True])
+        interval_thread._run = Mock()
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_has_calls([call(interval)])
+
+    def test_run_has_error(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, False,
+                                                          False, True])
+        interval_thread._run = Mock(side_effect=Exception)
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_has_calls([call(interval)])
+
+    def test_run_has_error_and_terminated(self):
+        oneshot = False
+        interval = 20  # Seconds
+        interval_thread = self.setup_interval_thread(oneshot=oneshot,
+                                                     interval=interval)
+        interval_thread.is_terminated = Mock(side_effect=[False, True,
+                                                          True, True])
+        interval_thread._run = Mock(side_effect=Exception)
+        interval_thread.wait = Mock()
+        interval_thread.run()
+        interval_thread.wait.assert_not_called()

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -26,7 +26,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config
+from virtwho.config import Config, ConfigManager
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,
@@ -41,6 +41,10 @@ class TestOptions(TestBase):
 
     def setUp(self):
         self.clearEnv()
+
+    def tearDown(self):
+        self.clearEnv()
+        super(TestBase, self).tearDown()
 
     def clearEnv(self):
         for key in os.environ.keys():
@@ -233,298 +237,40 @@ class TestOptions(TestBase):
                             continue
                         self.assertRaises(OptionError, parseOptions)
 
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.config.parseFile')
-    def test_sending_guests(self, parseFile, fromOptions, from_config, getLogger):
-        self.setUpParseFile(parseFile)
-        options = Mock()
-        options.oneshot = True
-        options.interval = 0
-        options.print_ = False
-        fake_virt = Mock()
-        fake_virt.CONFIG_TYPE = 'esx'
-        test_hypervisor = Hypervisor('test', guestIds=[Guest('guest1', fake_virt, 1)])
-        association = {'hypervisors': [test_hypervisor]}
-        options.log_dir = ''
-        options.log_file = ''
-        getLogger.return_value = sentinel.logger
+class TestExecutor(TestBase):
 
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-        config = Config("test", "esx", server="localhost", username="username",
-                        password="password", owner="owner", env="env")
-        expected_virt = Mock()
-        expected_virt.config = config
-        from_config.return_value = expected_virt
-        virtwho.configManager.addConfig(config)
-        test_queue = Queue()
-        virtwho.queue = test_queue
-        virtwho.queue.put(HostGuestAssociationReport(config, association))
-        virtwho.run()
+    @patch.object(Executor, 'terminate_threads')
+    @patch('virtwho.executor.time')
+    def test_wait_on_threads(self, mock_time, mock_terminate_threads):
+        """
+        Tests that, given no kwargs, the wait_on_threads method will wait until
+        all threads is_terminated method returns True.
+        Please note that a possible consequence of something going wrong in
+        the wait on threads method (with no kwargs) could cause this test to
+        never quit.
+        """
+        # Create a few mock threads
+        # The both will return False the first time is_terminated is called
+        # Only the second mock thread will wait not return True until the
+        # third call of is_terminated
+        mock_thread1 = Mock()
+        mock_thread1.is_terminated = Mock(side_effect=[False, True])
+        mock_thread2 = Mock()
+        mock_thread2.is_terminated = Mock(side_effect=[False, False, True])
 
-        from_config.assert_called_with(sentinel.logger, config, test_queue,
-                                       terminate_event=virtwho.terminate_event,
-                                       interval=options.interval,
-                                       oneshot=options.oneshot)
-        self.assertTrue(from_config.return_value.start.called)
-        fromOptions.assert_called_with(self.logger, options, ANY)
+        threads = [mock_thread1, mock_thread2]
 
+        mock_time.sleep = Mock()
+        Executor.wait_on_threads(threads)
+        mock_time.sleep.assert_has_calls([
+            call(1),
+            call(1),
+        ])
+        mock_terminate_threads.assert_not_called()
 
-class TestSend(TestBase):
-    def setUp(self):
-        self.config = Config('config', 'esx', server='localhost',
-                             username='username', password='password',
-                             owner='owner', env='env', log_dir='', log_file='')
-        self.second_config = Config('second_config', 'esx', server='localhost',
-                                    username='username', password='password',
-                                    owner='owner', env='env', log_dir='',
-                                    log_file='')
-        fake_virt = Mock()
-        fake_virt.CONFIG_TYPE = 'esx'
-        guests = [Guest('guest1', fake_virt, 1)]
-        test_hypervisor = Hypervisor('test', guestIds=[Guest('guest1', fake_virt, 1)])
-        assoc = {'hypervisors': [test_hypervisor]}
-        self.fake_domain_list = DomainListReport(self.second_config, guests)
-        self.fake_report = HostGuestAssociationReport(self.config, assoc)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_report_hash_added_after_send(self, from_config, fromOptions, getLogger):
-        # Side effect for from_config
-        def fake_virts(logger, config, dest, **kwargs):
-            new_fake_virt = Mock()
-            new_fake_virt.config.name = config.name
-            return new_fake_virt
-
-        from_config.side_effect = fake_virts
-        options = Mock()
-        options.interval = 0
-        options.oneshot = True
-        options.print_ = False
-        options.log_file = ''
-        options.log_dir = ''
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-
-        def send(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            return True
-        virtwho.send = Mock(side_effect=send)
-        queue = Queue()
-        virtwho.queue = queue
-        virtwho.retry_after = 1
-        virtwho.configManager.addConfig(self.config)
-        virtwho.configManager.addConfig(self.second_config)
-        queue.put(self.fake_report)
-        queue.put(self.fake_domain_list)
-        virtwho.run()
-
-        self.assertEquals(virtwho.send.call_count, 2)
-        self.assertEqual(virtwho.last_reports_hash[self.config.name], self.fake_report.hash)
-        self.assertEqual(virtwho.last_reports_hash[self.second_config.name], self.fake_domain_list.hash)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_same_report_filtering(self, from_config, fromOptions, getLogger):
-        def fake_virts(logger, config, dest, **kwargs):
-            new_fake_virt = Mock()
-            new_fake_virt.config.name = config.name
-            return new_fake_virt
-
-        from_config.side_effect = fake_virts
-        options = Mock()
-        options.interval = 0
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(self.logger, options, config_dir="/nonexistant")
-
-        queue = Queue()
-        # Create another report with same hash
-        report2 = HostGuestAssociationReport(self.config, self.fake_report.association)
-        self.assertEqual(self.fake_report.hash, report2.hash)
-
-        def send(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            # Put second report when the first is done
-            queue.put(report2)
-            return True
-        virtwho.send = Mock(side_effect=send)
-        virtwho.queue = queue
-        virtwho.retry_after = 1
-        virtwho.configManager.addConfig(self.config)
-        queue.put(self.fake_report)
-        virtwho.run()
-
-        self.assertEquals(virtwho.send.call_count, 1)
-
-    @patch('time.time')
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_send_current_report(self, from_config, fromOptions, getLogger, time):
-        initial = 10
-        time.side_effect = [initial, initial]
-
-        fromOptions.return_value = Mock()
-        options = Mock()
-        options.interval = 6
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-        virtwho.oneshot_remaining = ['config_name']
-
-        config = Mock()
-        config.hash = "config_hash"
-        config.name = "config_name"
-
-        virtwho.send = Mock()
-        virtwho.send.return_value = True
-        report = HostGuestAssociationReport(config, {'hypervisors': {}})
-        report.state = AbstractVirtReport.STATE_PROCESSING
-        virtwho.queued_reports[config.name] = report
-
-        virtwho.send_current_report()
-
-        def check_report_state(report):
-            report.state = AbstractVirtReport.STATE_FINISHED
-        virtwho.check_report_state = Mock(side_effect=check_report_state)
-        virtwho.check_reports_state()
-
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + options.interval)
-
-    @patch('time.time')
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.manager.Manager.fromOptions')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_send_current_report_with_429(self, from_config, fromOptions, getLogger, time):
-        initial = 10
-        retry_after = 2
-        time.return_value = initial
-
-        fromOptions.return_value = Mock()
-        options = Mock()
-        options.interval = 6
-        options.oneshot = True
-        options.print_ = False
-        options.log_dir = ''
-        options.log_file = ''
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-
-        config = Mock()
-        config.hash = "config_hash"
-        config.name = "config_name"
-
-        report = HostGuestAssociationReport(config, {'hypervisors': []})
-        report.state = AbstractVirtReport.STATE_PROCESSING
-        virtwho.queued_reports[config.name] = report
-
-        virtwho.send = Mock()
-        virtwho.send.return_value = False
-        virtwho.send.side_effect = ManagerThrottleError(retry_after)
-
-        virtwho.send_current_report()
-
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + 60)
-        self.assertEquals(len(virtwho.queued_reports), 1)
-
-        retry_after = 120
-        virtwho.send.side_effect = ManagerThrottleError(retry_after)
-        virtwho.send_current_report()
-        virtwho.send.assert_called_with(report)
-        self.assertEquals(virtwho.send_after, initial + retry_after * 2)
-        self.assertEquals(len(virtwho.queued_reports), 1)
-
-        def finish(x):
-            report.state = AbstractVirtReport.STATE_FINISHED
-            return True
-        virtwho.send.side_effect = finish
-        virtwho.send_current_report()
-        retry_after = 60
-        self.assertEquals(virtwho.retry_after, retry_after)
-        self.assertEquals(virtwho.send_after, initial + options.interval)
-        self.assertEquals(len(virtwho.queued_reports), 0)
-
-
-class TestReload(TestBase):
-    def mock_virtwho(self):
-        options = Mock()
-        options.interval = 6
-        options.oneshot = False
-        options.print_ = False
-        virtwho = Executor(Mock(), options, config_dir="/nonexistant")
-        config = Config("env/cmdline", 'libvirt')
-        virtwho.configManager.addConfig(config)
-        virtwho.queue = Mock()
-        virtwho.send = Mock()
-        return virtwho
-
-    def assertStartStop(self, from_config):
-        ''' Make sure that Virt was started and stopped. '''
-        self.assertTrue(from_config.return_value.start.called)
-        self.assertTrue(from_config.return_value.stop.called)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_start_unregistered(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        virtwho.queue.get.side_effect = [DomainListReport(virtwho.configManager.configs[0], []), Empty, 'reload']
-        virtwho.send.side_effect = ManagerFatalError
-        # When not registered, it should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-        # queue.get should be called 3 times: report, nonblocking reading
-        # of remaining reports and after ManagerFatalError wait indefinately
-        self.assertEqual(virtwho.queue.get.call_count, 3)
-        # It should wait blocking for the reload
-        virtwho.queue.get.assert_has_calls([call(block=True)])
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_exit_after_unregister(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send two reports and then 'exit'
-        virtwho.queue.get.side_effect = [report, Empty, report, Empty, 'exit']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [True, ManagerFatalError]
-        # _main should exit normally
-        _main(virtwho)
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_reload_after_unregister(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send two reports and then 'reload'
-        virtwho.queue.get.side_effect = [report, Empty, report, Empty, 'reload']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [True, ManagerFatalError]
-        # _main should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-        self.assertStartStop(from_config)
-
-    @patch('virtwho.log.getLogger')
-    @patch('virtwho.virt.Virt.from_config')
-    def test_reload_after_register(self, from_config, getLogger):
-        virtwho = self.mock_virtwho()
-        report = DomainListReport(virtwho.configManager.configs[0], [])
-        # Send report and then 'reload'
-        virtwho.queue.get.side_effect = [report, Empty, 'reload']
-        # First report will be successful, second one will throw ManagerFatalError
-        virtwho.send.side_effect = [ManagerFatalError, True]
-        # _main should throw ReloadRequest
-        self.assertRaises(ReloadRequest, _main, virtwho)
-
-        self.assertEqual(virtwho.queue.get.call_count, 3)
-        # It should wait blocking for the reload
-        virtwho.queue.get.assert_has_calls([call(block=True)])
-        self.assertStartStop(from_config)
+    def test_terminate_threads(self):
+        threads = [Mock(), Mock()]
+        Executor.terminate_threads(threads)
+        for mock_thread in threads:
+            mock_thread.stop.assert_called()
+            mock_thread.join.assert_called()

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -20,8 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import sys
 import os
-from Queue import Empty
-from multiprocessing import Queue
+from Queue import Empty, Queue
 from mock import patch, Mock, sentinel, ANY, call
 
 from base import TestBase
@@ -463,7 +462,7 @@ class TestReload(TestBase):
     def assertStartStop(self, fromConfig):
         ''' Make sure that Virt was started and stopped. '''
         self.assertTrue(fromConfig.return_value.start.called)
-        self.assertTrue(fromConfig.return_value.terminate.called)
+        self.assertTrue(fromConfig.return_value.stop.called)
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.virt.Virt.fromConfig')

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -37,12 +37,12 @@ class TestXen(TestBase):
     def setUp(self):
         config = Config('test', 'xen', server='localhost', username='username',
                         password='password', owner='owner', env='env')
-        self.xen = Xen(self.logger, config)
+        self.xen = Xen(self.logger, config, None)
 
     def run_once(self, queue=None):
         ''' Run XEN in oneshot mode '''
         self.xen._oneshot = True
-        self.xen._queue = queue or Queue()
+        self.xen.dest = queue or Queue()
         self.xen._terminate_event = Event()
         self.xen._oneshot = True
         self.xen._interval = 0

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -21,7 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import os
 import urllib2
 from mock import patch, call, ANY
-from multiprocessing import Queue, Event
+from threading import Event
+from Queue import Queue
 
 from base import TestBase
 from proxy import Proxy

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -133,7 +133,7 @@ class Info(object):
         if name.startswith('_'):
             super(object, self).__setattr__(name, value)
             return
-        self._set_option(name, value)
+        self._options[name] = value
 
     def __getattr__(self, name):
         if name.startswith('_'):

--- a/virtwho/datastore.py
+++ b/virtwho/datastore.py
@@ -1,0 +1,69 @@
+"""
+Module for reading configuration files
+
+Copyright (C) 2017 Christopher Snyder <csnyder@redhat.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+from threading import Lock
+
+
+class Datastore(object):
+    """ This class is a threadsafe datastore"""
+
+    def __init__(self, *args, **kwargs):
+        self._datastore = dict()
+        self._datastore_lock = Lock()
+
+    def put(self, key, value):
+        """
+        Stores the value, retrievable by key, in a threadsafe manner in the
+        underlying datastore. (Assumes all items are pickleable)
+
+        @param key: The unique identifier for this value
+        @type  key: str
+
+        @param value: The object to store
+        """
+        with self._datastore_lock:
+            to_store = pickle.dumps(value)
+            self._datastore[key] = to_store
+
+    def get(self, key, default=None):
+        """
+        Retrieves the value for the given key, in a threadsafe manner from the
+        underlying datastore. (Assumes all items in the datastore are pickled)
+
+        @param key: The unique identifier for this value
+        @type  key: str
+
+        @param default: An optional default object to return should the
+        underlying datastore not have an item for the given key.
+
+        @raises KeyError: A KeyError is raised when the underlying datastore
+        has no item for the given key and a default has not been provided.
+        """
+        with self._datastore_lock:
+            try:
+                item = pickle.loads(self._datastore[key])
+                return item
+            except KeyError:
+                if default:
+                    return default
+                raise

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -1,6 +1,6 @@
 import time
-from multiprocessing import Event, Queue
-from Queue import Empty
+from threading import Event
+from Queue import Empty, Queue
 import errno
 import socket
 
@@ -300,7 +300,6 @@ class Executor(object):
     def stop_virts(self):
         for virt in self.virts:
             virt.stop()
-            virt.terminate()
             virt.join()
         self.virts = []
 

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -8,11 +8,13 @@ import sys
 from virtwho import log, MinimumSendInterval
 
 from virtwho.config import ConfigManager
+from virtwho.datastore import Datastore
 from virtwho.manager import (
     Manager, ManagerThrottleError, ManagerError, ManagerFatalError)
 from virtwho.virt import (
     AbstractVirtReport, ErrorReport, DomainListReport,
-    HostGuestAssociationReport, Virt)
+    HostGuestAssociationReport, Virt, DestinationThread,
+    info_to_destination_class)
 
 try:
     from collections import OrderedDict
@@ -38,317 +40,198 @@ class Executor(object):
         self.options = options
         self.terminate_event = Event()
         self.virts = []
+        self.destinations = []
 
         # Queue for getting events from virt backends
-        self.queue = None
-
-        # Dictionary with mapping between config names and report hashes,
-        # used for checking if the report changed from last time
-        self.last_reports_hash = {}
-        # How long should we wait between reports sent to server
-        self.retry_after = MinimumSendInterval
-        # This counts the number of responses of http code 429
-        # received between successfully sent reports
-        self._429_count = 0
+        self.datastore = Datastore()
         self.reloading = False
-
-        # Reports that are queued for sending
-        self.queued_reports = OrderedDict()
-
-        # Name of configs that wasn't reported in oneshot mode
-        self.oneshot_remaining = set()
-
-        # Reports that are currently processed by server
-        self.reports_in_progress = []
 
         self.configManager = ConfigManager(self.logger, config_dir)
 
         for config in self.configManager.configs:
             logger.debug("Using config named '%s'" % config.name)
 
-        self.send_after = time.time()
-
-    def check_report_state(self, report):
-        ''' Check state of one report that is being processed on server. '''
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.check_report_state(report)
-
-    def check_reports_state(self):
-        ''' Check status of the reports that are being processed on server. '''
-        if not self.reports_in_progress:
-            return
-        updated = []
-        for report in self.reports_in_progress:
-            self.check_report_state(report)
-            if report.state == AbstractVirtReport.STATE_CREATED:
-                self.logger.warning("Can't check status of report that is not yet sent")
-            elif report.state == AbstractVirtReport.STATE_PROCESSING:
-                updated.append(report)
-            else:
-                self.report_done(report)
-        self.reports_in_progress = updated
-
-    def send_current_report(self):
-        name, report = self.queued_reports.popitem(last=False)
-        return self.send_report(name, report)
-
-    def send_report(self, name, report):
-        try:
-            if self.send(report):
-                # Success will reset the 429 count
-                if self._429_count > 0:
-                    self._429_count = 1
-                    self.retry_after = MinimumSendInterval
-
-                self.logger.debug('Report for config "%s" sent', name)
-                if report.state == AbstractVirtReport.STATE_PROCESSING:
-                    self.reports_in_progress.append(report)
-                else:
-                    self.report_done(report)
-            else:
-                report.state = AbstractVirtReport.STATE_FAILED
-                self.logger.debug('Report from "%s" failed to sent', name)
-                self.report_done(report)
-        except ManagerThrottleError as e:
-            self.queued_reports[name] = report
-            self._429_count += 1
-            self.retry_after = max(MinimumSendInterval, e.retry_after * self._429_count)
-            self.send_after = time.time() + self.retry_after
-            self.logger.debug('429 received, waiting %s seconds until sending again', self.retry_after)
-
-    def report_done(self, report):
-        name = report.config.name
-        self.send_after = time.time() + self.options.interval
-        if report.state == AbstractVirtReport.STATE_FINISHED:
-            self.last_reports_hash[name] = report.hash
-
-        if self.options.oneshot:
-            try:
-                self.oneshot_remaining.remove(name)
-            except KeyError:
-                pass
-
-    def send(self, report):
+    def _create_virt_backends(self):
         """
-        Send list of uuids to subscription manager
-
-        return - True if sending is successful, False otherwise
+        Create virts list with virt backend threads
         """
-        try:
-            if isinstance(report, DomainListReport):
-                self._sendGuestList(report)
-            elif isinstance(report, HostGuestAssociationReport):
-                self._sendGuestAssociation(report)
-            else:
-                self.logger.warn("Unable to handle report of type: %s", type(report))
-        except ManagerError as e:
-            self.logger.error("Unable to send data: %s", str(e))
-            return False
-        except ManagerFatalError:
-            raise
-        except ManagerThrottleError:
-            raise
-        except socket.error as e:
-            if e.errno == errno.EINTR:
-                self.logger.debug("Communication with subscription manager interrupted")
-            return False
-        except Exception as e:
-            if self.reloading:
-                # We want to skip error reporting when reloading,
-                # it is caused by interrupted syscall
-                self.logger.debug("Communication with subscription manager interrupted")
-                return False
-            exceptionCheck(e)
-            self.logger.exception("Error in communication with subscription manager:")
-            return False
-        return True
-
-    def _sendGuestList(self, report):
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.sendVirtGuests(report, self.options)
-
-    def _sendGuestAssociation(self, report):
-        manager = Manager.fromOptions(self.logger, self.options, report.config)
-        manager.hypervisorCheckIn(report, self.options)
-
-    def run(self):
-        self.reloading = False
-        if not self.options.oneshot:
-            self.logger.debug("Starting infinite loop with %d seconds interval", self.options.interval)
-
-        # Queue for getting events from virt backends
-        if self.queue is None:
-            self.queue = Queue()
-
-        # Run the virtualization backends
-        self.virts = []
+        virts = []
         for config in self.configManager.configs:
             try:
                 logger = log.getLogger(config=config)
-                virt = Virt.from_config(logger, config, self.queue,
+                virt = Virt.from_config(logger, config, self.datastore,
                                         terminate_event=self.terminate_event,
                                         interval=self.options.interval,
                                         oneshot=self.options.oneshot)
             except Exception as e:
                 self.logger.error('Unable to use configuration "%s": %s', config.name, str(e))
                 continue
-            # Run the thread
-            virt.start()
-            self.virts.append(virt)
+            virts.append(virt)
+        return virts
 
-        # This set is used both for oneshot mode and to bypass rate-limit
-        # when virt-who is starting
-        self.oneshot_remaining = set(virt.config.name for virt in self.virts)
+    def _create_destinations(self):
+        """Populate self.destinations with a list of  list with them
+
+            @param reset: Whether to kill existing destinations or not, defaults
+            to false
+            @type: bool
+        """
+        dests = []
+        for info in self.configManager.dests:
+            # Dests should already include all destinations we want created
+            # at this time. This method will make no assumptions of creating
+            # defaults of any kind.
+            source_keys = self.configManager.dest_to_sources_map[info]
+            info.name = "destination_%s" % hash(info)
+            logger = log.getLogger(name=info.name)
+            manager = Manager.fromInfo(logger, self.options, info)
+            dest_class = info_to_destination_class[type(info)]
+            dest = dest_class(config=info, logger=logger,
+                              source_keys=source_keys,
+                              options=self.options,
+                              source=self.datastore, dest=manager,
+                              terminate_event=self.terminate_event,
+                              interval=self.options.interval,
+                              oneshot=self.options.oneshot)
+            dests.append(dest)
+        return dests
+
+    @staticmethod
+    def wait_on_threads(threads, max_wait_time=None, kill_on_timeout=False):
+        """
+        Wait for each of the threads in the list to be terminated
+        @param threads: A list of IntervalThread objects to wait on
+        @type threads: list
+
+        @param max_wait_time: An optional max amount of seconds to wait
+        @type max_wait_time: int
+
+        @param kill_on_timeout: An optional arg that, if truthy and
+        max_wait_time is defined and exceeded, cause this method to attempt
+        to terminate and join the threads given it.
+        @type kill_on_timeout: bool
+
+        @return: A list of threads that have not quit yet. Without a
+        max_wait_time this list is always empty (or we are stuck waiting).
+        With a max_wait_time this list will include those threads that have
+        not quit yet.
+        @rtype: list
+        """
+        total_waited = 0
+        threads_not_terminated = list(threads)
+        while len(threads_not_terminated) > 0:
+            if max_wait_time is not None and total_waited > max_wait_time:
+                if kill_on_timeout:
+                    Executor.terminate_threads(threads_not_terminated)
+                    return []
+                return threads_not_terminated
+            for thread in threads_not_terminated:
+                if thread.is_terminated():
+                    threads_not_terminated.remove(thread)
+            if not threads_not_terminated:
+                break
+            time.sleep(1)
+            if max_wait_time is not None:
+                total_waited += 1
+        return threads_not_terminated
+
+    @staticmethod
+    def terminate_threads(threads):
+        for thread in threads:
+            thread.stop()
+            thread.join()
+
+    def run_oneshot(self):
+        # Start all sources
+        self.virts = self._create_virt_backends()
 
         if len(self.virts) == 0:
             err = "virt-who can't be started: no suitable virt backend found"
             self.logger.error(err)
+            self.terminate()
             sys.exit(err)
 
-        # queued reports depend on OrderedDict feature that if key exists
-        # when setting an item, it will remain in the same order
-        self.queued_reports.clear()
+        self.destinations = self._create_destinations()
 
-        # Clear last reports, we need to resend them when reloaded
-        self.last_reports_hash.clear()
+        if len(self.destinations) == 0:
+            err = "virt-who can't be started: no suitable destinations found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
 
-        # List of reports that are being processed by server
-        self.reports_in_progress = []
+        for thread in self.virts:
+            thread.start()
 
-        # Send the first report immediately
-        self.send_after = time.time()
+        Executor.wait_on_threads(self.virts)
 
-        while not self.terminate_event.is_set():
-            if self.reports_in_progress:
-                # Check sent report status regularly
-                timeout = 1
-            elif time.time() > self.send_after:
-                if self.queued_reports:
-                    # Reports are queued and we can send them right now,
-                    # don't wait in queue
-                    timeout = 0
-                else:
-                    # No reports in progress or queued and we can send report
-                    # immediately, we can wait for report as long as we want
-                    timeout = 3600
-            else:
-                # We can't send report right now, wait till we can
-                timeout = max(1, self.send_after - time.time())
-
-            # Wait for incoming report from virt backend or for timeout
-            try:
-                report = self.queue.get(block=True, timeout=timeout)
-            except Empty:
-                report = None
-            except IOError:
-                continue
-
-            # Read rest of the reports from the queue in order to remove
-            # obsoleted reports from same virt
-            while True:
-                if isinstance(report, ErrorReport):
-                    if self.options.oneshot:
-                        # Don't hang on the failed backend
-                        try:
-                            self.oneshot_remaining.remove(report.config.name)
-                        except KeyError:
-                            pass
-                        self.logger.warn('Unable to collect report for config "%s"', report.config.name)
-                elif isinstance(report, AbstractVirtReport):
-                    if self.last_reports_hash.get(report.config.name, None) == report.hash:
-                        self.logger.info('Report for config "%s" hasn\'t changed, not sending', report.config.name)
-                    else:
-                        if report.config.name in self.oneshot_remaining:
-                            # Send the report immediately
-                            self.oneshot_remaining.remove(report.config.name)
-                            if not self.options.print_:
-                                self.send_report(report.config.name, report)
-                            else:
-                                self.queued_reports[report.config.name] = report
-                        else:
-                            self.queued_reports[report.config.name] = report
-                elif report in ['exit', 'reload']:
-                    # Reload and exit reports takes priority, do not process
-                    # any other reports
-                    break
-
-                # Get next report from queue
-                try:
-                    report = self.queue.get(block=False)
-                except Empty:
-                    break
-
-            if report == 'exit':
-                break
-            elif report == 'reload':
-                self.stop_virts()
-                raise ReloadRequest()
-
-            self.check_reports_state()
-
-            if not self.reports_in_progress and self.queued_reports and time.time() > self.send_after:
-                # No report is processed, send next one
-                if not self.options.print_:
-                    self.send_current_report()
-
-            if self.options.oneshot and not self.oneshot_remaining and not self.reports_in_progress:
-                break
-
-        self.queue = None
-        self.stop_virts()
-
-        self.virt = []
         if self.options.print_:
-            return self.queued_reports
+            to_print = {}
+            for source in self.configManager.sources:
+                try:
+                    report = self.datastore.get(source)
+                    config = report.config
+                    to_print[config] = report
+                except KeyError:
+                    self.logger.info('Unable to retrieve report for source '
+                                     '\"%s\" for printing' % source)
+            return to_print
 
-    def stop_virts(self):
-        for virt in self.virts:
-            virt.stop()
-            virt.join()
-        self.virts = []
+        for thread in self.destinations:
+            thread.start()
+
+        Executor.wait_on_threads(self.destinations)
+
+    def run(self):
+        self.logger.debug("Starting infinite loop with %d seconds interval", self.options.interval)
+
+        # Need to update the dest to source mapping of the configManager object
+        # here because of the way that main reads the config from the command
+        # line
+        # TODO: Update dests to source map on addition or removal of configs
+        self.configManager.update_dest_to_source_map()
+        # Start all sources
+        self.virts = self._create_virt_backends()
+
+        if len(self.virts) == 0:
+            err = "virt-who can't be started: no suitable virt backend found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
+
+        self.destinations = self._create_destinations()
+        if len(self.destinations) == 0:
+            err = "virt-who can't be started: no suitable destinations found"
+            self.logger.error(err)
+            self.terminate()
+            sys.exit(err)
+
+        for thread in self.virts:
+            thread.start()
+
+        for thread in self.destinations:
+            thread.start()
+
+        # Interruptibly wait on the other threads to be terminated
+        self.wait_on_threads(self.destinations)
+
+        self.terminate()
+
+    def stop_threads(self):
+        self.terminate_event.set()
+        self.terminate_threads(self.virts)
+        self.terminate_threads(self.destinations)
 
     def terminate(self):
         self.logger.debug("virt-who is shutting down")
-
-        # Terminate the backends before clearing the queue, the queue must be empty
-        # to end a child process, otherwise it will be stuck in queue.put()
-        self.terminate_event.set()
-        # Give backends some time to terminate properly
-        time.sleep(0.5)
-
-        if self.queue:
-            # clear the queue and put "exit" there
-            try:
-                while True:
-                    self.queue.get(False)
-            except Empty:
-                pass
-            self.queue.put("exit")
-
-        # Give backends some more time to terminate properly
-        time.sleep(0.5)
-
-        self.stop_virts()
+        self.stop_threads()
+        self.virts = []
+        self.destinations = []
+        self.datastore = None
 
     def reload(self):
-        self.logger.warn("virt-who reload")
-        # Set the terminate event in all the virts
-        for virt in self.virts:
-            virt.stop()
-        # clear the queue and put "reload" there
-        try:
-            while True:
-                self.queue.get(False)
-        except Empty:
-            pass
-        self.reloading = True
-        self.queue.put("reload")
-
-
-def exceptionCheck(e):
-    try:
-        # This happens when connection to server is interrupted (CTRL+C or signal)
-        if e.args[0] == errno.EALREADY:
-            exit(0)
-    except Exception:
-        pass
+        """
+        Causes all threads to be terminated in preparation for running again
+        """
+        self.stop_threads()
+        self.terminate_event.clear()
+        self.datastore = Datastore()

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -26,8 +26,7 @@ import cStringIO
 import os
 import sys
 import json
-from Queue import Empty
-from multiprocessing import Queue
+from Queue import Empty, Queue
 from threading import Thread
 
 from virtwho import util

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -249,7 +249,7 @@ def exit(code, status=None):
         except KeyboardInterrupt:
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             for v in executor.virts:
-                v.terminate()
+                v.stop()
                 v.join()
     if log.hasQueueLogger():
         queueLogger = log.getQueueLogger()

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -39,20 +39,18 @@ from virtwho.parser import parseOptions, OptionError
 from virtwho.password import InvalidKeyFile
 from virtwho.virt import DomainListReport, HostGuestAssociationReport
 
-
 try:
     from systemd.daemon import notify as sd_notify
 except ImportError:
     def sd_notify(status, unset_environment=False):
         pass
 
-
 # Disable Insecure Request warning from requests library
 try:
-    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+    requests.packages.urllib3.disable_warnings(
+        requests.packages.urllib3.exceptions.InsecureRequestWarning)
 except AttributeError:
     pass
-
 
 PIDFILE = "/var/run/virt-who.pid"
 
@@ -70,7 +68,8 @@ class PIDLock(object):
                 return True
             except OSError:
                 # Process no longer exists
-                print >>sys.stderr, "PID file exists but associated process does not, deleting PID file"
+                print >> sys.stderr, "PID file exists but associated process " \
+                                     "does not, deleting PID file"
                 os.remove(self.filename)
                 return False
         except Exception:
@@ -79,10 +78,12 @@ class PIDLock(object):
     def __enter__(self):
         # Write pid to pidfile
         try:
-            with os.fdopen(os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600), 'w') as f:
+            with os.fdopen(
+                    os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600),
+                    'w') as f:
                 f.write("%d" % os.getpid())
         except Exception as e:
-            print >>sys.stderr, "Unable to create pid file: %s" % str(e)
+            print >> sys.stderr, "Unable to create pid file: %s" % str(e)
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
@@ -104,6 +105,8 @@ def atexit_fn(*args, **kwargs):
 def reload(signal, stackframe):
     if executor:
         executor.reload()
+        raise ReloadRequest()
+    exit(1, status="virt-who cannot reload, exiting")
 
 
 def main():
@@ -111,13 +114,14 @@ def main():
     try:
         logger, options = parseOptions()
     except OptionError as e:
-        print >>sys.stderr, str(e)
+        print >> sys.stderr, str(e)
         exit(1, status="virt-who can't be started: %s" % str(e))
 
     lock = PIDLock(PIDFILE)
     if lock.is_locked():
-        msg = "virt-who seems to be already running. If not, remove %s" % PIDFILE
-        print >>sys.stderr, msg
+        msg = "virt-who seems to be already running. If not, remove %s" % \
+              PIDFILE
+        print >> sys.stderr, msg
         exit(1, status=msg)
 
     global executor
@@ -128,7 +132,8 @@ def main():
         exit(1, "virt-who can't be started: %s" % str(e))
 
     if options.virtType is not None:
-        config = Config("env/cmdline", options.virtType, executor.configManager._defaults, **options)
+        config = Config("env/cmdline", options.virtType,
+                        executor.configManager._defaults, **options)
         try:
             config.checkOptions(logger)
         except InvalidOption as e:
@@ -145,7 +150,8 @@ def main():
             logger.error(err)
             exit(1, err)
         except Exception as e:
-            logger.error('Config file "%s" skipped because of an error: %s', conffile, str(e))
+            logger.error('Config file "%s" skipped because of an error: %s',
+                         conffile, str(e))
             has_error = True
 
     if len(executor.configManager.configs) == 0:
@@ -158,11 +164,22 @@ def main():
         logger.info("No configurations found, using libvirt as backend")
         executor.configManager.addConfig(Config("env/cmdline", "libvirt"))
 
+    executor.configManager.update_dest_to_source_map()
+
+    if len(executor.configManager.dests) == 0:
+        if has_error:
+            err = "virt-who can't be started: no valid destination found"
+            logger.error(err)
+            exit(1, err)
+
     for config in executor.configManager.configs:
         if config.name is None:
-            logger.info('Using commandline or sysconfig configuration ("%s" mode)', config.type)
+            logger.info(
+                'Using commandline or sysconfig configuration ("%s" mode)',
+                config.type)
         else:
-            logger.info('Using configuration "%s" ("%s" mode)', config.name, config.type)
+            logger.info('Using configuration "%s" ("%s" mode)', config.name,
+                        config.type)
 
     logger.info("Using reporter_id='%s'", options.reporter_id)
     log.closeLogger(logger)
@@ -175,7 +192,8 @@ def main():
         signal.signal(signal.SIGHUP, reload)
         signal.signal(signal.SIGTERM, atexit_fn)
 
-        executor.logger = logger = log.getLogger(name='main', config=None, queue=True)
+        executor.logger = logger = log.getLogger(name='main', config=None,
+                                                 queue=True)
 
         sd_notify("READY=1\nMAINPID=%d" % os.getpid())
         while True:
@@ -187,50 +205,47 @@ def main():
 
 
 def _main(executor):
-    result = None
-    try:
-        result = executor.run()
-    except ManagerFatalError:
-        executor.stop_virts()
-        executor.logger.exception("Fatal error:")
-        if not executor.options.oneshot:
-            executor.logger.info("Waiting for reload signal")
-            # Wait indefinitely until we get reload or exit signal
-            while True:
-                report = executor.queue.get(block=True)
-                if report == 'reload':
-                    raise ReloadRequest()
-                elif report == 'exit':
-                    return 0
+    if executor.options.oneshot:
+        result = executor.run_oneshot()
 
-    if executor.options.print_:
-        if not result:
-            executor.logger.error("No hypervisor reports found")
-            return 1
-        hypervisors = []
-        for config, report in result.items():
-            if isinstance(report, DomainListReport):
-                hypervisors.append({
-                    'guests': [guest.toDict() for guest in report.guests]
-                })
-            elif isinstance(report, HostGuestAssociationReport):
-                for hypervisor in report.association['hypervisors']:
-                    h = OrderedDict((
-                        ('uuid', hypervisor.hypervisorId),
-                        ('guests', [guest.toDict() for guest in hypervisor.guestIds])
-                    ))
-                    if hypervisor.facts:
-                        h['facts'] = hypervisor.facts
-                    if hypervisor.name:
-                        h['name'] = hypervisor.name
-                    hypervisors.append(h)
-        data = json.dumps({
-            'hypervisors': hypervisors
-        })
-        executor.logger.debug("Associations found: %s", json.dumps({
-            'hypervisors': hypervisors
-        }, indent=4, sort_keys=True))
-        print(data)
+        if executor.options.print_:
+            if not result:
+                executor.logger.error("No hypervisor reports found")
+                return 1
+            hypervisors = []
+            for config, report in result.items():
+                if isinstance(report, DomainListReport):
+                    hypervisors.append({
+                        'guests': [guest.toDict() for guest in report.guests]
+                    })
+                elif isinstance(report, HostGuestAssociationReport):
+                    for hypervisor in report.association['hypervisors']:
+                        h = OrderedDict((
+                            ('uuid', hypervisor.hypervisorId),
+                            ('guests',
+                             [guest.toDict() for guest in hypervisor.guestIds])
+                        ))
+                        if hypervisor.facts:
+                            h['facts'] = hypervisor.facts
+                        if hypervisor.name:
+                            h['name'] = hypervisor.name
+                        hypervisors.append(h)
+            data = json.dumps({
+                'hypervisors': hypervisors
+            })
+            executor.logger.debug("Associations found: %s", json.dumps({
+                'hypervisors': hypervisors
+            }, indent=4, sort_keys=True))
+            print(data)
+        return 0
+
+    # We'll get here only if we're not in oneshot or print_ mode (which
+    # implies oneshot)
+
+    # There should not be a way for us to leave this method unless it is time
+    #  to exit
+    executor.run()
+
     return 0
 
 
@@ -250,7 +265,12 @@ def exit(code, status=None):
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             for v in executor.virts:
                 v.stop()
-                v.join()
+                if v.ident:
+                    v.join()
+            for d in executor.destinations:
+                d.stop()
+                if d.ident:
+                    d.join()
     if log.hasQueueLogger():
         queueLogger = log.getQueueLogger()
         queueLogger.terminate()

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -26,6 +26,7 @@ import rhsm.connection as rhsm_connection
 import rhsm.certificate as rhsm_certificate
 import rhsm.config as rhsm_config
 
+from virtwho.config import NotSetSentinel
 from virtwho.manager import Manager, ManagerError, ManagerFatalError, ManagerThrottleError
 from virtwho.virt import AbstractVirtReport
 
@@ -56,13 +57,14 @@ class SubscriptionManager(Manager):
         self.logger = logger
         self.options = options
         self.cert_uuid = None
-
-        self.rhsm_config = rhsm_config.initConfig(rhsm_config.DEFAULT_CONFIG_PATH)
+        self.rhsm_config = None
         self.readConfig()
 
     def readConfig(self):
         """ Parse rhsm.conf in order to obtain consumer
             certificate and key paths. """
+        self.rhsm_config = rhsm_config.initConfig(
+            rhsm_config.DEFAULT_CONFIG_PATH)
         consumerCertDir = self.rhsm_config.get("rhsm", "consumerCertDir")
         cert = 'cert.pem'
         key = 'key.pem'
@@ -82,39 +84,43 @@ class SubscriptionManager(Manager):
             'proxy_password': self.rhsm_config.get('server', 'proxy_password'),
             'insecure': self.rhsm_config.get('server', 'insecure')
         }
+        kwargs_to_config = {
+            'host': 'rhsm_hostname',
+            'ssl_port': 'rhsm_port',
+            'handler': 'rhsm_prefix',
+            'proxy_hostname': 'rhsm_proxy_hostname',
+            'proxy_port': 'rhsm_proxy_port',
+            'proxy_user': 'rhsm_proxy_user',
+            'proxy_password': 'rhsm_proxy_password',
+            'insecure': 'rhsm_insecure'
+        }
 
         rhsm_username = None
         rhsm_password = None
 
         if config:
-            rhsm_username = config.rhsm_username
-            rhsm_password = config.rhsm_password
+            try:
+                rhsm_username = config['rhsm_username']
+                rhsm_password = config['rhsm_password']
+            except KeyError:
+                pass
+
+            if rhsm_username == NotSetSentinel:
+                rhsm_username = None
+            if rhsm_password == NotSetSentinel:
+                rhsm_password = None
 
             # Testing for None is necessary, it might be an empty string
-
-            if config.rhsm_hostname is not None:
-                kwargs['host'] = config.rhsm_hostname
-
-            if config.rhsm_port is not None:
-                kwargs['ssl_port'] = int(config.rhsm_port)
-
-            if config.rhsm_prefix is not None:
-                kwargs['handler'] = config.rhsm_prefix
-
-            if config.rhsm_proxy_hostname is not None:
-                kwargs['proxy_hostname'] = config.rhsm_proxy_hostname
-
-            if config.rhsm_proxy_port is not None:
-                kwargs['proxy_port'] = config.rhsm_proxy_port
-
-            if config.rhsm_proxy_user is not None:
-                kwargs['proxy_user'] = config.rhsm_proxy_user
-
-            if config.rhsm_proxy_password is not None:
-                kwargs['proxy_password'] = config.rhsm_proxy_password
-
-            if config.rhsm_insecure is not None:
-                kwargs['insecure'] = config.rhsm_insecure
+            for key, value in kwargs.iteritems():
+                try:
+                    from_config = config[kwargs_to_config[key]]
+                    if from_config is not NotSetSentinel and from_config is \
+                            not None:
+                        if key is 'ssl_port':
+                            from_config = int(from_config)
+                        kwargs[key] = from_config
+                except KeyError:
+                    continue
 
         if rhsm_username and rhsm_password:
             self.logger.debug("Authenticating with RHSM username %s", rhsm_username)

--- a/virtwho/virt/__init__.py
+++ b/virtwho/virt/__init__.py
@@ -2,8 +2,8 @@
 
 from virt import (Virt, VirtError, Guest, AbstractVirtReport, DomainListReport,
                   HostGuestAssociationReport, ErrorReport,
-                  Hypervisor)
+                  Hypervisor, DestinationThread)
 
 __all__ = ['Virt', 'VirtError', 'Guest', 'AbstractVirtReport',
            'DomainListReport', 'HostGuestAssociationReport',
-           'ErrorReport', 'Hypervisor']
+           'ErrorReport', 'Hypervisor', 'DestinationThread']

--- a/virtwho/virt/__init__.py
+++ b/virtwho/virt/__init__.py
@@ -2,8 +2,9 @@
 
 from virt import (Virt, VirtError, Guest, AbstractVirtReport, DomainListReport,
                   HostGuestAssociationReport, ErrorReport,
-                  Hypervisor, DestinationThread)
+                  Hypervisor, DestinationThread, IntervalThread, info_to_destination_class)
 
 __all__ = ['Virt', 'VirtError', 'Guest', 'AbstractVirtReport',
            'DomainListReport', 'HostGuestAssociationReport',
-           'ErrorReport', 'Hypervisor', 'DestinationThread']
+           'ErrorReport', 'Hypervisor', 'DestinationThread',
+           'IntervalThread', 'info_to_destination_class']

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -499,21 +499,30 @@ if __name__ == '__main__':  # pragma: no cover
     logger = logging.getLogger('virtwho.esx')
     logger.addHandler(logging.StreamHandler())
     from virtwho.config import Config
+    from virtwho.datastore import Datastore
+    from threading import Thread, Event
     config = Config('esx', 'esx', server=sys.argv[1], username=sys.argv[2],
                     password=sys.argv[3])
-    vsphere = Esx(logger, config)
-    from Queue import Queue
-    from threading import Event, Thread
-    q = Queue()
+    datastore = Datastore()
+    vsphere = Esx(logger, config, datastore)
+    printer_terminate_event = Event()
 
     class Printer(Thread):
         def run(self):
-            while True:
-                print(q.get(True).association)
+            last_hash = None
+            while not printer_terminate_event.is_set():
+                try:
+                    report = datastore.get(config.name)
+                    if report and report.hash != last_hash:
+                        print(report.association)
+                        last_hash = report.hash
+                except KeyError:
+                    pass
     p = Printer()
-    p.daemon = True
     p.start()
     try:
-        vsphere.start_sync(q, Event())
+        vsphere.start_sync()
     except KeyboardInterrupt:
+        printer_terminate_event.set()
+        p.join()
         sys.exit(1)

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -109,8 +109,12 @@ class Esx(virt.Virt):
     CONFIG_TYPE = "esx"
     MAX_WAIT_TIME = 300  # 5 minutes
 
-    def __init__(self, logger, config):
-        super(Esx, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Esx, self).__init__(logger, config, dest,
+                                  terminate_event=terminate_event,
+                                  interval=interval,
+                                  oneshot=oneshot)
         self.url = config.server
         self.username = config.username
         self.password = config.password
@@ -212,8 +216,8 @@ class Esx(virt.Virt):
 
             if last_version != version or time() > next_update:
                 assoc = self.getHostGuestMapping()
-                self.enqueue(virt.HostGuestAssociationReport(self.config, assoc))
-                next_update = time() + self._interval
+                self._send_data(virt.HostGuestAssociationReport(self.config, assoc))
+                next_update = time() + self.interval
                 last_version = version
 
             if self._oneshot:

--- a/virtwho/virt/fakevirt/fakevirt.py
+++ b/virtwho/virt/fakevirt/fakevirt.py
@@ -8,8 +8,12 @@ from virtwho.util import decode
 class FakeVirt(Virt):
     CONFIG_TYPE = 'fake'
 
-    def __init__(self, logger, config):
-        super(FakeVirt, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(FakeVirt, self).__init__(logger, config, dest,
+                                       terminate_event=terminate_event,
+                                       interval=interval,
+                                       oneshot=oneshot)
         self.logger = logger
         self.config = config
 

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -442,8 +442,12 @@ class HyperVCallFailed(HyperVException):
 class HyperV(virt.Virt):
     CONFIG_TYPE = "hyperv"
 
-    def __init__(self, logger, config):
-        super(HyperV, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(HyperV, self).__init__(logger, config, dest,
+                                     terminate_event=terminate_event,
+                                     interval=interval,
+                                     oneshot=oneshot)
         url = config.server
         self.username = config.username
         self.password = config.password

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -74,7 +74,7 @@ class Libvirtd(Virt):
     CONFIG_TYPE = "libvirt"
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False ,registerEvents=True):
+                 interval=None, oneshot=False, registerEvents=True):
         super(Libvirtd, self).__init__(logger, config, dest,
                                        terminate_event=terminate_event,
                                        interval=interval,

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -53,8 +53,12 @@ RHEVM_STATE_TO_GUEST_STATE = {
 class RhevM(virt.Virt):
     CONFIG_TYPE = "rhevm"
 
-    def __init__(self, logger, config):
-        super(RhevM, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(RhevM, self).__init__(logger, config, dest,
+                                    terminate_event=terminate_event,
+                                    interval=interval,
+                                    oneshot=oneshot)
         self.url = self.config.server
         if "//" not in self.url:
             self.url = "//" + self.config.server

--- a/virtwho/virt/vdsm/vdsm.py
+++ b/virtwho/virt/vdsm/vdsm.py
@@ -51,8 +51,12 @@ VDSM_STATE_TO_GUEST_STATE = {
 class Vdsm(Virt):
     CONFIG_TYPE = "vdsm"
 
-    def __init__(self, logger, config):
-        super(Vdsm, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Vdsm, self).__init__(logger, config, dest,
+                                   terminate_event=terminate_event,
+                                   interval=interval,
+                                   oneshot=oneshot)
         self._readConfig("/etc/vdsm/vdsm.conf")
 
     def isHypervisor(self):

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -28,6 +28,7 @@ import json
 import hashlib
 import re
 import fnmatch
+from virtwho.manager import ManagerError, ManagerThrottleError
 
 try:
     from collections import OrderedDict
@@ -262,29 +263,349 @@ class HostGuestAssociationReport(AbstractVirtReport):
         return hashlib.sha256(json.dumps(self.serializedAssociation, sort_keys=True)).hexdigest()
 
 
-class Virt(Thread):
-    '''
+class IntervalThread(Thread):
+    def __init__(self, logger, config, source=None, dest=None,
+                 terminate_event=None, interval=None, oneshot=False):
+        self.logger = logger
+        self.config = config
+        self.source = source
+        self.dest = dest
+        self._internal_terminate_event = Event()
+        self.terminate_event = terminate_event or self._internal_terminate_event
+        self.interval = interval or DefaultInterval
+        self._oneshot = oneshot
+        super(IntervalThread, self).__init__()
+        self.daemon = True
+
+    def wait(self, wait_time):
+        '''
+        Wait `wait_time` seconds, could be interrupted by setting _terminate_event or _internal_terminate_event.
+        '''
+        for i in range(wait_time):
+            if self.is_terminated():
+                break
+            time.sleep(1)
+
+    def is_terminated(self):
+        """
+
+        @return: Returns true if either the internal terminate event is set or
+                 the terminate event given in the init is set
+        """
+        return self._internal_terminate_event.is_set() or \
+            self.terminate_event.is_set()
+
+    def stop(self):
+        """
+        Causes this thread to stop at the next idle moment
+        """
+        self._internal_terminate_event.set()
+
+    def _run(self):
+        """
+        This method could be reimplemented in subclass to provide
+        it's own way of waiting for changes (like event monitoring)
+        """
+        self.prepare()
+        while not self.is_terminated():
+            start_time = datetime.now()
+            data_to_send = self._get_data()
+            self._send_data(data_to_send)
+            if self._oneshot:
+                break
+            end_time = datetime.now()
+
+            delta = end_time - start_time
+            # for python2.6, 2.7 has total_seconds method
+            delta_seconds = ((
+                             delta.days * 86400 + delta.seconds) * 10 ** 6 +
+                             delta.microseconds) / 10 ** 6
+
+            wait_time = self.interval - int(delta_seconds)
+
+            if wait_time < 0:
+                self.logger.debug(
+                    "Getting the data took longer than the configured "
+                    "interval. Trying again immediately.")
+                continue
+
+            self.wait(wait_time)
+
+    def _get_data(self):
+        """
+        This method gathers data from the source provided to the thread
+        @return: The data from the source
+        """
+        raise NotImplementedError("Should be implemented in subclasses")
+
+    def _send_data(self, data_to_send):
+        """
+        @param data_to_send: The data to be given to the dest
+        """
+        raise NotImplementedError("Should be implemented in subclasses")
+
+    def run(self):
+        '''
+        Wrapper around `_run` method that just catches the error messages.
+        '''
+        self.logger.debug("Thread '%s' started", self.config.name)
+        try:
+            while not self.is_terminated():
+                has_error = False
+                try:
+                    self._run()
+                except VirtError as e:
+                    if not self.is_terminated():
+                        self.logger.error("Thread '%s' fails with error: %s",
+                                          self.config.name, str(e))
+                        has_error = True
+                except Exception:
+                    if not self.is_terminated():
+                        self.logger.exception("Thread '%s' fails with "
+                                              "exception:", self.config.name)
+                        has_error = True
+
+                if self._oneshot:
+                    if has_error:
+                        self._send_data(ErrorReport(self.config))
+                    self.logger.debug("Thread '%s' stopped after sending one "
+                                      "report", self.config.name)
+                    return
+
+                if self.is_terminated():
+                    self.logger.debug("Thread '%s' terminated",
+                                      self.config.name)
+                    return
+
+                self.logger.info("Waiting %s seconds before performing action"
+                                 "again '%s'", self.interval, self.config.name)
+                self.wait(self.interval)
+        except KeyboardInterrupt:
+            self.logger.debug("Thread '%s' interrupted", self.config.name)
+            self.cleanup()
+            sys.exit(1)
+
+    def cleanup(self):
+        '''
+        Perform cleaning up actions before termination.
+        '''
+        pass
+
+    def prepare(self):
+        """
+        Do pre-mainloop initialization of the source and dest,
+        for example logging in.
+        """
+        pass
+
+
+class DestinationThread(IntervalThread):
+    """
+    This class is a thread that pulls reports from the datastore and sends them
+    to the actual destination (candlepin, Satellite, etc) using a manager
+    object.
+
+    This class should work so long as the destination is a Manager object.
+    """
+    def __init__(self, logger, config, source_keys=None, options=None,
+                 source=None, dest=None, terminate_event=None, interval=None,
+                 oneshot=False):
+        """
+        @param source_keys: A list of keys to be used to retrieve info from
+        the source
+        @type source_keys: list
+
+        @param source: The source to pull from
+        @type source: Datastore
+
+        @param dest: The destination object to use to actually send the data
+        @type dest: Manager
+        """
+        if not isinstance(source_keys, list):
+            raise ValueError("Source keys must be a list")
+        self.source_keys = source_keys
+        self.last_report_for_source = {}  # Source_key to hash of last report
+        self.options = options
+        super(DestinationThread, self).__init__(logger, config, source=source,
+                                                dest=dest,
+                                                terminate_event=terminate_event,
+                                                interval=interval,
+                                                oneshot=oneshot)
+        # The polling interval has not been implemented as configurable yet
+        # Until the config includes the polling_interval attribute
+        # this will end up being the interval.
+        try:
+            polling_interval = self.config.polling_interval
+        except AttributeError:
+            polling_interval = self.interval
+        self.polling_interval = polling_interval
+        # This is used when there is some reason to modify how long we wait
+        # EX when we get a 429 back from the server, this value will be the
+        # value of the retry_after header.
+        self.interval_modifier = 0
+
+    def _get_data(self):
+        """
+        Gets the latest report from the source for each source_key
+        @return: dict
+        """
+        reports = {}
+        for source_key in self.source_keys:
+            report = self.source.get(source_key, None)
+            if report.hash == self.last_report_for_source.get(source_key, None):
+                self.logger.debug('Duplicate report found, ignoring')
+                continue
+            reports[source_key] = report
+        return reports
+
+    def _send_data(self, data_to_send):
+        """
+        Processes the data_to_send and sends it using the dest object.
+        @param data_to_send: A dict of source_keys, report
+        @type: dict
+        """
+        if not data_to_send:
+            self.logger.debug('No data to send, waiting for next interval')
+            return
+        if isinstance(data_to_send, ErrorReport):
+            self.logger.info('Error report received, shutting down')
+            self._internal_terminate_event.set()
+            return
+
+        all_hypervisors = [] # All the Host-guest mappings together
+        DomainListReports = []  # Source_key to DomainListReport
+        reports_batched = []  # Reports put together and sent as one
+        sources_sent = []  # Sources we have dealt with this run
+
+        # Reports of different types are handled differently
+        for source_key, report in data_to_send.iteritems():
+            if isinstance(report, DomainListReport):
+                # These are sent one at a time to the destination
+                DomainListReports.append(source_key)
+                continue
+            if isinstance(report, HostGuestAssociationReport):
+                # These reports are put into one report to send at once
+                all_hypervisors.extend(report.association['hypervisors'])
+                # Keep track of those reports that we have
+                reports_batched.append(source_key)
+                continue
+            if isinstance(report, ErrorReport):
+                # These indicate an error that came from this source
+                # Log it and move along.
+                # if it was recoverable we'll get something else next time.
+                # if it was not recoverable we'll see this again from this
+                # source. Thus we'll just log this at the debug level.
+                self.logger.debug('ErrorReport received for source: %s' % source_key)
+                if self._oneshot:
+                    # Consider this source dealt with if we are in oneshot mode
+                    sources_sent.append(source_key)
+
+        if all_hypervisors:
+            # Modify the batched dict to be in the form expected for
+            # HostGuestAssociationReports
+            all_hypervisors = {'hypervisors': all_hypervisors}
+            batch_host_guest_report = HostGuestAssociationReport(self.config,
+                                                                 all_hypervisors)
+            result = None
+            while result is None:
+                try:
+                    result = self.dest.hypervisorCheckIn(batch_host_guest_report,
+                                                     options=self.options)
+                    break
+                except ManagerThrottleError as e:
+                    self.logger.debug("429 encountered while performing "
+                                      "hypervisor check in.\nTrying again in "
+                                      "%s" % e.retry_after)
+                    self.interval_modifier = e.retry_after
+                self.wait(wait_time=self.interval_modifier)
+                self.interval_modifier = 0
+            # Poll for async results if async
+            while batch_host_guest_report.state not in [
+                AbstractVirtReport.STATE_CANCELED,
+                AbstractVirtReport.STATE_FAILED,
+                AbstractVirtReport.STATE_FINISHED]:
+                if self.interval_modifier != 0:
+                    wait_time = self.interval_modifier
+                    self.interval_modifier = 0
+                else:
+                    wait_time = self.polling_interval
+                self.wait(wait_time=wait_time)
+                try:
+                    self.dest.check_report_state(batch_host_guest_report)
+                except ManagerThrottleError as e:
+                    self.logger.debug('429 encountered while checking job '
+                                      'state, checking again later')
+                    self.interval_modifier = e.retry_after
+
+            # If the batch report did not reach the finished state, we do not
+            #  want to update which report we last sent (as we might want to
+            #  try to send the same report again next time)
+            if batch_host_guest_report.state == \
+                    AbstractVirtReport.STATE_FINISHED:
+                # Update the hash of the info last sent for each source
+                # included in the successful report
+                for source_key in reports_batched:
+                    self.last_report_for_source[source_key] = data_to_send[
+                        source_key].hash
+                    sources_sent.append(source_key)
+
+        # Send each Domain Guest List Report if necessary
+        for source_key in DomainListReports:
+            report = data_to_send[source_key]
+            retry = True
+            while retry:  # Retry if we encounter a 429
+                try:
+                    self.dest.sendVirtGuests(report, options=self.options)
+                    sources_sent.append(source_key)
+                    self.last_report_for_source[source_key] = data_to_send[
+                        source_key].hash
+                    retry = False
+                except ManagerError:
+                    self.logger.debug("Error in manager, unable to send virt "
+                                      "guests for source: %s" % source_key)
+                    retry = False  # Only retry on 429
+                except ManagerThrottleError as e:
+                    self.logger.debug('429 encountered when sending virt '
+                                      'guests. Retrying after: %s' % e.retry_after)
+                    self.wait(wait_time=e.retry_after)
+
+        # Terminate this thread if we have sent one report for each source
+        if all(source_key in sources_sent for source_key in self.source_keys)\
+                and self._oneshot:
+            self.logger.debug('At least one report for each connected source '
+                              'has been sent. Terminating.')
+            self._internal_terminate_event.set()
+        if self._oneshot:
+            # Remove sources we have sent (or dealt with) so that we don't
+            # do extra work on the next run, should we have missed any sources
+            self.source_keys = [source_key for source_key in self.source_keys
+                                if source_key not in sources_sent]
+        return
+
+
+class Virt(IntervalThread):
+    """
     Virtualization backend abstract class.
 
     This class must be inherited for each of the virtualization backends.
 
     Run `start` method to start obtaining data about virtual guests. The data
-    will be pushed to the `queue` that is parameter of the `start` method.
+    will be pushed to the dest(ination) that is parameter of the `__init__`
+    method.
+    """
 
-    Note that this class is a subclass of `threading.Thread` class.
-    '''
-    def __init__(self, logger, config):
-        self.logger = logger
-        self.config = config
-        self._internal_terminate_event = Event()
-        super(Virt, self).__init__()
-        self.daemon = True
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Virt, self).__init__(logger, config, dest=dest,
+                                   terminate_event=terminate_event,
+                                   interval=interval, oneshot=oneshot)
 
     def __repr__(self):
         return '{1}({0.logger!r}, {0.config!r})'.format(self, self.__class__.__name__)
 
     @classmethod
-    def fromConfig(cls, logger, config):
+    def from_config(cls, logger, config, dest,
+                    terminate_event=None, interval=None, oneshot=False):
         """
         Create instance of inherited class based on the config.
         """
@@ -300,48 +621,18 @@ class Virt(Thread):
 
         for subcls in cls.__subclasses__():
             if config.type == subcls.CONFIG_TYPE:
-                return subcls(logger, config)
+                return subcls(logger, config, dest,
+                              terminate_event=terminate_event,
+                              interval=interval, oneshot=oneshot)
         raise KeyError("Invalid config type: %s" % config.type)
 
-    def start(self, queue, terminate_event, interval=None, oneshot=False):  # pylint: disable=W0221
-        '''
-        Start obtaining data from the hypervisor/host system. The data will
-        be fetched (as instances of AbstractVirtReport subclasses) to the
-        `queue` parameter (which should be instance of `Queue.Queue` object.
-
-        `terminate_event` is `threading.Event` instance and will be set when
-        the thread should be terminated.
-
-        `interval` parameter determines maximal interval, how ofter should
-        the data be reported. If the virt backend supports events, it might
-        be less often.
-
-        If `oneshot` parameter is True, the data will be reported only once
-        and the thread will be terminated after that.
-        '''
-        self._queue = queue
-        self._terminate_event = terminate_event
-        if interval is not None:
-            self._interval = interval
-        else:
-            self._interval = DefaultInterval
-        self._oneshot = oneshot
-        super(Virt, self).start()
-
-    def start_sync(self, queue, terminate_event, interval=None, oneshot=False):
+    def start_sync(self):
         '''
         This method is same as `start()` but runs synchronously, it does NOT
         create new thread.
 
         Use it only in specific cases!
         '''
-        self._queue = queue
-        self._terminate_event = terminate_event
-        if interval is not None:
-            self._interval = interval
-        else:
-            self._interval = DefaultInterval
-        self._oneshot = oneshot
         self._run()
 
     def _get_report(self):
@@ -350,96 +641,21 @@ class Virt(Thread):
         else:
             return DomainListReport(self.config, self.listDomains())
 
-    def wait(self, wait_time):
-        '''
-        Wait `wait_time` seconds, could be interrupted by setting _terminate_event or _internal_terminate_event.
-        '''
-        for i in range(wait_time):
-            if self.is_terminated():
-                break
-            time.sleep(1)
+    def _get_data(self):
+        """
+        Gathers the data from the source.
+        Could be overridden to specify how to get data other than a report.
+        For example in destination threads.
+        @return: The data from the source to be passed along to the dest
+        """
+        return self._get_report()
 
-    def stop(self):
-        self._internal_terminate_event.set()
-
-    def is_terminated(self):
-        return self._internal_terminate_event.is_set() or self._terminate_event.is_set()
-
-    def enqueue(self, report):
+    def _send_data(self, data_to_send):
         if self.is_terminated():
             sys.exit(0)
-        self.logger.debug('Report for config "%s" gathered, putting to queue for sending', report.config.name)
-        self._queue.put(report)
-
-    def run(self):
-        '''
-        Wrapper around `_run` method that just catches the error messages.
-        '''
-        self.logger.debug("Virt backend '%s' started", self.config.name)
-        try:
-            while not self.is_terminated():
-                has_error = False
-                try:
-                    self._run()
-                except VirtError as e:
-                    if not self.is_terminated():
-                        self.logger.error("Virt backend '%s' fails with error: %s", self.config.name, str(e))
-                        has_error = True
-                except Exception:
-                    if not self.is_terminated():
-                        self.logger.exception("Virt backend '%s' fails with exception:", self.config.name)
-                        has_error = True
-
-                if self._oneshot:
-                    if has_error:
-                        self.enqueue(ErrorReport(self.config))
-                    self.logger.debug("Virt backend '%s' stopped after sending one report", self.config.name)
-                    return
-
-                if self.is_terminated():
-                    self.logger.debug("Virt backend '%s' terminated", self.config.name)
-                    return
-
-                self.logger.info("Waiting %s seconds before retrying backend '%s'", self._interval, self.config.name)
-                self.wait(self._interval)
-        except KeyboardInterrupt:
-            self.logger.debug("Virt backend '%s' interrupted", self.config.name)
-            self.cleanup()
-            sys.exit(1)
-
-    def _run(self):
-        '''
-        Run the endless loop that will fill the `_queue` with reports.
-
-        This method could be reimplemented in subclass to provide
-        it's own way of waiting for changes (like event monitoring)
-        '''
-        self.prepare()
-        while not self.is_terminated():
-            start_time = datetime.now()
-            report = self._get_report()
-            self.enqueue(report)
-            if self._oneshot:
-                break
-            end_time = datetime.now()
-
-            delta = end_time - start_time
-            # for python2.6, 2.7 has total_seconds method
-            delta_seconds = ((delta.days * 86400 + delta.seconds) * 10**6 + delta.microseconds) / 10**6
-
-            wait_time = self._interval - int(delta_seconds)
-
-            if wait_time < 0:
-                self.logger.debug("Getting the host/guests association took too long, interval waiting is skipped")
-                continue
-
-            self.wait(wait_time)
-
-    def prepare(self):
-        '''
-        Do pre-mainloop initialization of the backend, for example logging in.
-        '''
-        pass
+        self.logger.debug('Report for config "%s" gathered, placing in '
+                          'datastore', data_to_send.config.name)
+        self.dest.put(data_to_send)
 
     def isHypervisor(self):
         """
@@ -463,9 +679,3 @@ class Virt(Thread):
         return value of isHypervisor method.
         '''
         raise NotImplementedError('This should be reimplemented in subclass')
-
-    def cleanup(self):
-        '''
-        Perform cleaning up actions before termination.
-        '''
-        pass

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -26,7 +26,6 @@ from datetime import datetime
 from threading import Thread, Event
 import json
 import hashlib
-import signal
 import re
 import fnmatch
 

--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -210,19 +210,30 @@ if __name__ == "__main__":  # pragma: no cover
     logger.addHandler(logging.StreamHandler())
     url, username, password = sys.argv[1:4]
     config = Config('xen', 'xen', server=url, username=username, password=password)
-    xenserver = Xen(logger, config)
-    from Queue import Queue
+    from virtwho.datastore import Datastore
     from threading import Event, Thread
-    q = Queue()
+    printer_terminate_event = Event()
+    datastore = Datastore()
+
+    xenserver = Xen(logger, config, datastore)
 
     class Printer(Thread):
         def run(self):
-            while True:
-                print q.get(True).association
+            last_hash = None
+            while not printer_terminate_event.is_set():
+                try:
+                    report = datastore.get(config.name)
+                    if report and report.hash != last_hash:
+                        print report.association
+                        last_hash = report.hash
+                except KeyError:
+                    pass
     p = Printer()
     p.daemon = True
     p.start()
     try:
-        xenserver.start_sync(q, Event())
+        xenserver.start_sync()
     except KeyboardInterrupt:
+        printer_terminate_event.set()
+        p.join()
         sys.exit(1)

--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -25,8 +25,12 @@ class Xen(virt.Virt):
     # Register for events on all classes
     event_types = ["host", "vm"]
 
-    def __init__(self, logger, config):
-        super(Xen, self).__init__(logger, config)
+    def __init__(self, logger, config, dest, terminate_event=None,
+                 interval=None, oneshot=False):
+        super(Xen, self).__init__(logger, config, dest,
+                                  terminate_event=terminate_event,
+                                  interval=interval,
+                                  oneshot=oneshot)
         self.url = config.server
         self.username = config.username
         self.password = config.password
@@ -186,8 +190,8 @@ class Xen(virt.Virt):
 
             if initial or len(events) > 0 or delta > 0:
                 assoc = self.getHostGuestMapping()
-                self.enqueue(virt.HostGuestAssociationReport(self.config, assoc))
-                next_update = time() + self._interval
+                self._send_data(virt.HostGuestAssociationReport(self.config, assoc))
+                next_update = time() + self.interval
                 initial = False
 
             if self._oneshot:


### PR DESCRIPTION
This set of changes allows virt-who to send all reports (batched where possible) on the interval for each destination. Reports for different destinations no longer block each other and cause check in times to increase. This allows virt-who to be set up more effectively for large organizations having some set of hypervisors that need to be reported to more than one organization or environment or even more than one satellite!