### PR TITLE
1439317: Ensure reports are still sent despite duplicate configurations

### DIFF
--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -606,7 +606,7 @@ class ConfigManager(object):
                                                             dest_classes):
                 dests.add(dest)
                 current_sources = dest_to_source_map.get(dest, set())
-                current_sources.symmetric_difference_update(set([config.name]))
+                current_sources.update(set([config.name]))
                 sources_without_destinations.difference_update(
                         set([config.name]))
                 dest_to_source_map[dest] = current_sources


### PR DESCRIPTION
Let's say you have one configuration in /etc/virt-who.d/ named 'test.conf'

Given the above, running 'virt-who -o -d --config /etc/virt-who.d/test.conf' will cause virt-who to start, collect reports, and fail to send anything to the server.

This should not be the case. Even made to read the same config twice there should not be a lack of communication with the end destination. This PR fixes that by changing the set operation done on update of the dest_to_source map.

Please note: When you try the above you will likely notice that there are two source threads started, each for the same actual source of information. This is not necessary and should likely be fixed. It is not fixed here as it is historical behaviour.