### PR TITLE
Do not join threads not started, fix up fake backend

### DIFF
--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -139,7 +139,8 @@ class Executor(object):
     def terminate_threads(threads):
         for thread in threads:
             thread.stop()
-            thread.join()
+            if thread.ident:
+                thread.join()
 
     def run_oneshot(self):
         # Start all sources

--- a/virtwho/virt/fakevirt/fakevirt.py
+++ b/virtwho/virt/fakevirt/fakevirt.py
@@ -17,7 +17,7 @@ class FakeVirt(Virt):
         self.logger = logger
         self.config = config
 
-    def _get_data(self):
+    def _read_data(self):
         # TODO: do some checking of the file content
         try:
             with open(self.config.file, 'r') as f:
@@ -47,14 +47,14 @@ class FakeVirt(Virt):
     def getHostGuestMapping(self):
         assoc = {'hypervisors': []}
         try:
-            for hypervisor in self._get_data()['hypervisors']:
+            for hypervisor in self._read_data()['hypervisors']:
                 assoc['hypervisors'].append(self._process_hypervisor(hypervisor))
         except KeyError as e:
             raise VirtError("Fake virt file '%s' is not properly formed: %s" % (self.config.file, str(e)))
         return assoc
 
     def listDomains(self):
-        hypervisor = self._get_data()['hypervisors'][0]
+        hypervisor = self._read_data()['hypervisors'][0]
         if 'uuid' in hypervisor:
             raise VirtError("Fake virt file '%s' is not properly formed: "
                             "uuid key shouldn't be present, try to check is_hypervisor value" %


### PR DESCRIPTION
These are some bits that needed a bit of love post interval design.
The fake virt backend already had a method _get_data that was overriding the new super classes version of the method.
We certain threads fail to run properly in oneshot mode, it was possible to fail with a runtime exeception (and stall the process). This was due to an attempt to join a thread not started. This PR fixes that. In future builds, please add this as part of the RFE for the interval bits.