### PR TITLE
1436517: Fix 404 on RHEV detection

### DIFF
--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -113,7 +113,7 @@ class RhevM(virt.Virt):
                                     auth=self.auth,
                                     headers=headers,
                                     verify=False)
-            if response.status_code == 404 and 'ovirt-engine' not in self.url:
+            if response.status_code == 404:
                 response = requests.get(urlparse.urljoin(self.url, 'ovirt-engine/api'),
                                         auth=self.auth,
                                         headers=headers,


### PR DESCRIPTION
Fix the 404 caused by url provided containing /ovirt-engine/, but
urlparse.urljoin removing /ovirt-engine/