### PR TITLE
1442337: Send updates immediately the first run

### DIFF
--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -114,6 +114,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=True, options=options)
+        destination_thread.is_initial_run = False
         result_data = destination_thread._get_data()
         self.assertEquals(result_data, datastore)
 
@@ -148,6 +149,7 @@ class TestDestinationThread(TestBase):
                                                terminate_event=terminate_event,
                                                oneshot=True,
                                                options=options)
+        destination_thread.is_initial_run = False
         destination_thread.last_report_for_source = last_report_for_source
         result_data = destination_thread._get_data()
         self.assertEquals(result_data, expected_data)
@@ -497,6 +499,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=False, options=options)
+        destination_thread.is_initial_run = False
         destination_thread._send_data(data_to_send=data_to_send)
 
         expected_hashes = {}

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -46,6 +46,7 @@ STATE_MAPPING = {
     'FAILED': AbstractVirtReport.STATE_FAILED,
     'RUNNING': AbstractVirtReport.STATE_PROCESSING,
     'WAITING': AbstractVirtReport.STATE_PROCESSING,
+    'CREATED': AbstractVirtReport.STATE_PROCESSING,
 }
 
 

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -228,6 +228,11 @@ class Esx(virt.Virt):
     def _format_hostname(self, host, domain):
         return u'{0}.{1}'.format(host, domain)
 
+    def stop(self):
+        # We need to ensure that when we stop the thread, we clean up and exit the wait
+        self.cleanup()
+        super(Esx, self).stop()
+
     def cleanup(self):
         self._cancel_wait()
 


### PR DESCRIPTION
To restore some historical behaviour that was lost during the implementation of the interval design, this PR causes virt-who to send all known reports as soon as it has received something from each source on the initial run.

With out this PR you must wait one interval before virt-who sends anything.