### PR TITLE
1369107: Update docs and log message to show the *.conf requirement

### DIFF
--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -4,17 +4,17 @@ virt-who-config - configuration for virt-who
 .SH SYNOPISIS
 /etc/sysconfig/virt-who
 /etc/virt-who.conf
-/etc/virt-who.d/*
+/etc/virt-who.d/*.conf
 .SH DESCRIPTION
-Configuration format is ini-like for files /etc/virt-who.conf and /etc/virt-who.d/*.
+Configuration format is ini-like for files /etc/virt-who.conf and /etc/virt-who.d/*.conf.
 The contents of /etc/sysconfig/virt-who are environment variables to be used when virt-who is run as a service.
-The configuration files located at /etc/virt-who.d/ are called virtualization backend configurations.
-All non-hidden files in this directory are considered configuration files. If no section (name in square brackets) is present in the configuration file, it will be ignored and warning will be shown.
+The configuration files located at /etc/virt-who.d/*.conf are called virtualization backend configurations.
+All non-hidden files in this directory (ending in '.conf') are considered configuration files. If no section (name in square brackets) is present in the configuration file, it will be ignored and warning will be shown.
 The configuration located at /etc/virt-who.conf is the main configuration for virt-who.
 Below are descriptions of both the required and optional options for both kinds of configs and how they are used.
 .SH GENERAL CONFIGURATION
 The general configuration file (located at /etc/virt-who.conf), has two special sections \fBglobal\fR and \fBdefaults\fR.
-The settings that can be specified in \fBdefaults\fR are any setting listed in the \fBVIRTUALIZATION BACKEND CONFIGURATION\fR section of this manual. These settings are applied as defaults to the configurations found in /etc/virt-who.d/*.
+The settings that can be specified in \fBdefaults\fR are any setting listed in the \fBVIRTUALIZATION BACKEND CONFIGURATION\fR section of this manual. These settings are applied as defaults to the configurations found in /etc/virt-who.d/*.conf.
 
 The settings in the \fBglobal\fR affect the overall operation of the application.
 The following are options that can be specified in the \fBglobal\fR section:

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -524,12 +524,26 @@ class ConfigManager(object):
         self.sources = set()
         self.dests = set()
         self.dest_to_sources_map = {}
+        all_dir_content = None
+        conf_files = None
+        non_conf_files = None
         try:
-            config_dir_content = [s for s in os.listdir(config_dir) if s.endswith('.conf')]
+            all_dir_content = set(os.listdir(config_dir))
+            conf_files = set(s for s in all_dir_content if s.endswith('.conf'))
+            non_conf_files = all_dir_content - conf_files
         except OSError:
             self.logger.warn("Configuration directory '%s' doesn't exist or is not accessible", config_dir)
             return
-        for conf in config_dir_content:
+        if not all_dir_content:
+            self.logger.warn("Configuration directory '%s' appears empty", config_dir)
+        elif not conf_files:
+            self.logger.warn("Configuration directory '%s' does not have any '*.conf' files but "
+                             "is not empty", config_dir)
+        elif non_conf_files:
+            self.logger.debug("There are files in '%s' not ending in '*.conf' is this "
+                              "intentional?", config_dir)
+
+        for conf in conf_files:
             if conf.startswith('.'):
                 continue
             try:

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -161,7 +161,8 @@ def main():
             exit(1, err)
         # In order to keep compatibility with older releases of virt-who,
         # fallback to using libvirt as default virt backend
-        logger.info("No configurations found, using libvirt as backend")
+        logger.info("No configurations found (are there any '.conf' files in /etc/virt-who.d?), "
+                    "using libvirt as backend")
         executor.configManager.addConfig(Config("env/cmdline", "libvirt"))
 
     executor.configManager.update_dest_to_source_map()


### PR DESCRIPTION
These updates are related to the implementation of the RFE bug 1369107.
Herein are changes to the documentation as well as one of the log messages to help communicate the new requirement for config files to end in '.conf'.