### PR TITLE
1448267: Fix polling behavior for oneshot, CTRL-C, 429 responses

### DIFF
--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -305,6 +305,7 @@ class TestDestinationThread(TestBase):
         # In this test we want to see that the wait method is called when we
         # expect and with what parameters we expect
         destination_thread.wait = Mock()
+        destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
         # We expect there two be two calls to wait with the value of the
         # polling_interval attr because we'd like to wait one polling
@@ -339,7 +340,7 @@ class TestDestinationThread(TestBase):
                         'source2': report2}
         config = Mock()
         config.polling_interval = 10
-        error_to_throw = ManagerThrottleError(retry_after=20)
+        error_to_throw = ManagerThrottleError(retry_after=62)
 
         manager = Mock()
         manager.hypervisorCheckIn.return_value = report1
@@ -374,8 +375,9 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=False, options=options)
         destination_thread.wait = Mock()
+        destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
         destination_thread.wait.assert_has_calls(expected_wait_calls)
 
@@ -412,6 +414,7 @@ class TestDestinationThread(TestBase):
                                                terminate_event=terminate_event,
                                                oneshot=True, options=options)
         destination_thread.wait = Mock()
+        destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
         manager.sendVirtGuests.assert_has_calls([call(report1,
                                                       options=destination_thread.options)])
@@ -436,7 +439,7 @@ class TestDestinationThread(TestBase):
         config.polling_interval = 10
         logger = Mock()
 
-        error_to_throw = ManagerThrottleError(retry_after=21)
+        error_to_throw = ManagerThrottleError(retry_after=62)
 
         manager = Mock()
         manager.sendVirtGuests = Mock(side_effect=[error_to_throw, report1])
@@ -450,12 +453,11 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=False, options=options)
         destination_thread.wait = Mock()
+        destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
         manager.sendVirtGuests.assert_has_calls([call(report1,
-                                                      options=destination_thread.options),
-                                                 call(report1,
                                                       options=destination_thread.options)])
         destination_thread.wait.assert_has_calls([call(
                 wait_time=error_to_throw.retry_after)])
@@ -500,6 +502,7 @@ class TestDestinationThread(TestBase):
                                                terminate_event=terminate_event,
                                                oneshot=False, options=options)
         destination_thread.is_initial_run = False
+        destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send=data_to_send)
 
         expected_hashes = {}

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -31,6 +31,7 @@ import fnmatch
 from virtwho.config import NotSetSentinel, Satellite5DestinationInfo, \
     Satellite6DestinationInfo, DefaultDestinationInfo
 from virtwho.manager import ManagerError, ManagerThrottleError, ManagerFatalError
+from virtwho import MinimumSendInterval
 
 try:
     from collections import OrderedDict
@@ -424,6 +425,27 @@ class IntervalThread(Thread):
         """
         pass
 
+    @staticmethod
+    def handle_429(retry_after, number_of_failures):
+        """
+        @param retry_after: The value of the Retry-After header (if included)
+        @type retry_after: int
+        @param number_of_failures: The number of failures that have happened attempting the same
+        request.
+        @type retry_after: int
+
+        @return: The number of seconds that should be waited before retrying
+        @rtype: int
+        """
+        wait_time = retry_after
+        if wait_time and wait_time >= MinimumSendInterval:
+            return wait_time
+        if number_of_failures > 0:
+            wait_time = MinimumSendInterval * number_of_failures
+        else:
+            wait_time = MinimumSendInterval
+        return wait_time
+
 
 class DestinationThread(IntervalThread):
     """
@@ -577,32 +599,41 @@ class DestinationThread(IntervalThread):
             result = None
             # Try to actually do the checkin whilst being mindful of the
             # rate limit (retrying where necessary)
-            while result is None:
+            num_429_received = 0
+            while result is None and not self.is_terminated():
                 try:
                     result = self.dest.hypervisorCheckIn(
                             batch_host_guest_report,
                             options=self.options)
                     break
                 except ManagerThrottleError as e:
+                    if self._oneshot:
+                        self.logger.debug('429 encountered while performing hypervisor checkin in '
+                                          'oneshot mode, not retrying')
+                        sources_erred.extend(reports_batched)
+                        break
+                    num_429_received += 1
+                    retry_after = self.handle_429(e.retry_after, num_429_received)
                     self.logger.debug("429 encountered while performing "
                                       "hypervisor check in.\n"
                                       "Trying again in "
-                                      "%s" % e.retry_after)
-                    self.interval_modifier = e.retry_after
+                                      "%s", retry_after)
+                    self.interval_modifier = retry_after
                 except (ManagerError, ManagerFatalError):
                     self.logger.exception("Error during hypervisor "
-                                        "checkin: ")
+                                          "checkin: ")
                     if self._oneshot:
                         sources_erred.extend(reports_batched)
                     break
                 self.wait(wait_time=self.interval_modifier)
                 self.interval_modifier = 0
             initial_job_check = True
+            num_429_received = 0
             # Poll for async results if async (retrying where necessary)
             while result and batch_host_guest_report.state not in [
                 AbstractVirtReport.STATE_CANCELED,
                 AbstractVirtReport.STATE_FAILED,
-                AbstractVirtReport.STATE_FINISHED]:
+                AbstractVirtReport.STATE_FINISHED] and not self.is_terminated():
                 if self.interval_modifier != 0:
                     wait_time = self.interval_modifier
                     self.interval_modifier = 0
@@ -613,9 +644,15 @@ class DestinationThread(IntervalThread):
                 try:
                     self.dest.check_report_state(batch_host_guest_report)
                 except ManagerThrottleError as e:
+                    if self._oneshot:
+                        self.logger.debug('429 encountered when checking job state in '
+                                          'oneshot mode, not retrying')
+                        sources_sent.extend(reports_batched)
+                        break
+                    retry_after = self.handle_429(e.retry_after, num_429_received)
                     self.logger.debug('429 encountered while checking job '
-                                      'state, checking again later')
-                    self.interval_modifier = e.retry_after
+                                      'state, checking again in "%s"', retry_after)
+                    self.interval_modifier = retry_after
                 except (ManagerError, ManagerFatalError):
                     self.logger.exception("Error during job check: ")
                     if self._oneshot:
@@ -639,7 +676,8 @@ class DestinationThread(IntervalThread):
             report = data_to_send[source_key]
             if not self.options.print_:
                 retry = True
-                while retry:  # Retry if we encounter a 429
+                num_429_received = 0
+                while retry and not self.is_terminated():  # Retry if we encounter a 429
                     try:
                         self.dest.sendVirtGuests(report, options=self.options)
                         sources_sent.append(source_key)
@@ -647,10 +685,17 @@ class DestinationThread(IntervalThread):
                             source_key].hash
                         retry = False
                     except ManagerThrottleError as e:
+                        if self._oneshot:
+                            self.logger.debug('429 encountered when sending virt guests in '
+                                             'oneshot mode, not retrying')
+                            sources_erred.append(source_key)
+                            break
+                        num_429_received += 1
+                        retry_after = self.handle_429(e.retry_after, num_429_received)
                         self.logger.debug('429 encountered when sending virt '
                                           'guests.'
-                                          'Retrying after: %s' % e.retry_after)
-                        self.wait(wait_time=e.retry_after)
+                                          'Retrying after: %s', retry_after)
+                        self.wait(wait_time=retry_after)
                     except (ManagerError, ManagerFatalError):
                         self.logger.exception("Fatal error during send virt "
                                               "guests: ")
@@ -713,7 +758,8 @@ class Satellite5DestinationThread(DestinationThread):
                 # one communication via Satellite 5. As such we'll just do a
                 # hypervisor check in for each report of that type.
                 result = None
-                while result is None:
+                num_429_received = 0
+                while result is None and not self.is_terminated():
                     try:
                         result = self.dest.hypervisorCheckIn(
                                 report,
@@ -722,11 +768,18 @@ class Satellite5DestinationThread(DestinationThread):
                         sources_sent.append(source_key)
                         break
                     except ManagerThrottleError as e:
+                        if self._oneshot:
+                            self.logger.debug('429 encountered during hypervisor checkin in '
+                                             'oneshot mode, not retrying')
+                            sources_erred.append(source_key)
+                            break
+                        num_429_received += 1
+                        retry_after = self.handle_429(e.retry_after, num_429_received)
                         self.logger.debug("429 encountered while performing "
                                           "hypervisor check in.\n"
                                           "Trying again in "
-                                          "%s" % e.retry_after)
-                        self.interval_modifier = e.retry_after
+                                          "%s", retry_after)
+                        self.interval_modifier = retry_after
                     except ManagerFatalError:
                         self.logger.exception("Fatal error during hypervisor "
                                               "checkin: ")


### PR DESCRIPTION
This PR fixes the behaviour of polling when in oneshot mode, when CTRL-C is pressed, and when a http 429 response is received.

In oneshot mode, virt-who will make one attempt to report on each source at most. If any exception occurs during communication (including http 429), virt-who will move on. This is restoring the historical behaviour of virt-who oneshot mode.

When CTRL-C is pressed (to kill the virt-who process) virt-who now exits without polling or making additional connections. Prior to this PR, virt-who would start polling as fast as it could until it was successful.

When an http 429 is received virt-who will check for the existence of a Retry-After header. If provided and more than the minimumSendInterval (currently 60s) then that value will be used as the wait time until the request is retried. If not provided (or less than the minimumSendInterval) the time virt-who will wait will be the minimumSendInterval * number_of_429_responses_in_a_row. So the first 429 received for a given request (without the Retry-After header) will result in a wait time of 60s. The second will result in a wait time of 120s and so on.