### PR TITLE
1447264: Keep running on InvalidPasswordFormat given other valid configs

### DIFF
--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -561,6 +561,8 @@ class ConfigManager(object):
                 self._configs.append(config)
             except NoOptionError as e:
                 self.logger.error(str(e))
+            except InvalidPasswordFormat as e:
+                self.logger.error(str(e))
 
     def readFile(self, filename):
         parser = StripQuotesConfigParser()


### PR DESCRIPTION
Seemed like a quick fix to the referenced bug.
Basically, if we fail to decrypt the password for a config, log it and continue (if there are other configs left to run with).