### PR TITLE
1450747: Continue running destination threads on internal failure

### DIFF
--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -537,8 +537,9 @@ class DestinationThread(IntervalThread):
             self.logger.debug('No data to send, waiting for next interval')
             return
         if isinstance(data_to_send, ErrorReport):
-            self.logger.info('Error report received, shutting down')
-            self.stop()
+            self.logger.info('Error report received')
+            if data_to_send.config.name != self.config.name:
+                self.stop()
             return
         all_hypervisors = [] # All the Host-guest mappings together
         domain_list_reports = []  # Source_keys of DomainListReports


### PR DESCRIPTION
The behaviour of virt-who prior to the implementation of the interval design, was to continue running despite connection failures when attempting to send reports.

This PR applies the same behaviour to the new design.

When reviewing this PR, in order to see the difference in behaviour for yourself, please follow the reproduction steps in the bug https://bugzilla.redhat.com/show_bug.cgi?id=1450747