### PR TITLE
1409984: Retry initial report retrieval on connection timeout

### DIFF
--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -178,7 +178,7 @@ class Esx(virt.Virt):
                     version=version,
                     options=options)
                 initial = False
-            except (socket.error, URLError):
+            except (socket.error, URLError, requests.exceptions.Timeout):
                 self.logger.debug("Wait for ESX event finished, timeout")
                 self._cancel_wait()
                 # Get the initial update again


### PR DESCRIPTION
The underlying connection will timeout in the event that there are no hosts to report on. In this case we should continue to try until there are hosts available.