### PR TITLE
1457101: Continue running despite malformed configs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,7 +189,13 @@ type=invalid
 server=1.2.3.4
 username=test
 """)
-        self.assertRaises(InvalidOption, ConfigManager, self.logger, self.config_dir)
+        # Instantiating the ConfigManager with an invalid config should not fail
+        # instead we expect that the list of configs managed by the ConfigManager does not
+        # include the invalid one
+        config_manager = ConfigManager(self.logger, self.config_dir)
+        # There should be no configs parsed successfully, therefore the list of configs should
+        # be empty
+        self.assertEqual(len(config_manager.configs), 0)
 
     @unittest.skipIf(os.getuid() == 0, "Can't create unreadable file when running as root")
     def testUnreadableConfig(self):
@@ -286,7 +292,13 @@ env=staging
 [test]
 type=esx
 """)
-        self.assertRaises(InvalidOption, ConfigManager, self.logger, self.config_dir)
+        # Instantiating the ConfigManager with an invalid config should not fail
+        # instead we expect that the list of configs managed by the ConfigManager does not
+        # include the invalid one
+        config_manager = ConfigManager(self.logger, self.config_dir)
+        # There should be no configs parsed successfully, therefore the list of configs should
+        # be empty
+        self.assertEqual(len(config_manager.configs), 0)
 
     def testMultipleConfigsInFile(self):
         config_1 = combine_dicts(TestReadingConfigs.source_options_1,
@@ -528,7 +540,13 @@ password=password
 owner=root
 rhsm_hostname=abc
 """)
-        self.assertRaises(InvalidOption, ConfigManager, self.logger, self.config_dir)
+        # Instantiating the ConfigManager with an invalid config should not fail
+        # instead we expect that the list of configs managed by the ConfigManager does not
+        # include the invalid one
+        config_manager = ConfigManager(self.logger, self.config_dir)
+        # There should be no configs parsed successfully, therefore the list of configs should
+        # be empty
+        self.assertEqual(len(config_manager.configs), 0)
 
     def testMissingOwnerOption(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -541,7 +559,39 @@ password=password
 env=env
 rhsm_hostname=abc
 """)
-        self.assertRaises(InvalidOption, ConfigManager, self.logger, self.config_dir)
+        # Instantiating the ConfigManager with an invalid config should not fail
+        # instead we expect that the list of configs managed by the ConfigManager does not
+        # include the invalid one
+        config_manager = ConfigManager(self.logger, self.config_dir)
+        # There should be no configs parsed successfully, therefore the list of configs should
+        # be empty
+        self.assertEqual(len(config_manager.configs), 0)
+
+    def testInvalidAndValidConfigs(self):
+        valid_config_name = "valid_config"
+        with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
+            f.write("""
+[%(valid_config_name)s]
+type=esx
+server=1.2.3.4
+username=admin
+password=password
+owner=owner
+env=env
+rhsm_hostname=abc
+
+[invalid_missing_owner]
+type=esx
+server=1.2.3.4
+username=admin
+password=password
+env=env
+rhsm_hostname=abc
+""" % {'valid_config_name': valid_config_name})
+        config_manager = ConfigManager(self.logger, self.config_dir)
+        # There should be only one config, and that should be the one that is valid
+        self.assertEqual(len(config_manager.configs), 1)
+        self.assertEquals(config_manager.configs[0].name, valid_config_name)
 
     def testInvisibleConfigFile(self):
         with open(os.path.join(self.config_dir, ".test1.conf"), "w") as f:

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -577,6 +577,10 @@ class ConfigManager(object):
                 self.logger.error(str(e))
             except InvalidPasswordFormat as e:
                 self.logger.error(str(e))
+            except InvalidOption as e:
+                # When a configuration section has an Invalid Option, continue
+                # See https://bugzilla.redhat.com/show_bug.cgi?id=1457101 for more info
+                self.logger.warn("Invalid configuration detected: %s", str(e))
 
     def readFile(self, filename):
         parser = StripQuotesConfigParser()


### PR DESCRIPTION
We'd like virt-who to continue to run when there are configurations that are invalid.
Should there be no configs that are valid virt-who will default to local libvirt.