### PR TITLE
1389729: virt-who incorrectly reports 'name' instead of 'hostname'

### DIFF
--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -53,6 +53,7 @@ HOSTS_XML = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <hosts>
     <host href="/api/hosts/{host}" id="{host}">
         <name>hostname.domainname</name>
+        <address>hostname.domainname</address>
         <cluster href="/api/clusters/{cluster}" id="{cluster}"/>
         <cpu>
             <topology sockets="1" cores="6" threads="2"/>

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -208,7 +208,7 @@ class RhevM(virt.Virt):
                     self.logger.warn("Host %s doesn't have hardware uuid", id)
                     continue
             elif self.config.hypervisor_id == 'hostname':
-                host_id = host.find('name').text
+                host_id = host.find('address').text
             else:
                 raise virt.VirtError(
                     'Invalid option %s for hypervisor_id, use one of: uuid, hwuuid, or hostname' %
@@ -232,7 +232,7 @@ class RhevM(virt.Virt):
             except AttributeError:
                 pass
 
-            hosts[id] = virt.Hypervisor(hypervisorId=host_id, name=host.find('name').text, facts=facts)
+            hosts[id] = virt.Hypervisor(hypervisorId=host_id, name=host.find('address').text, facts=facts)
             mapping[id] = []
         for vm in vms_xml.findall('vm'):
             guest_id = vm.get('id')


### PR DESCRIPTION
1389729: virt-who incorrectly reports 'name' instead of 'hostname' for RHEV hosts.

This change makes virt-who report the actual hostname/IP address of the hypervisors, rather than the user-definable "hostname", which might not be an RFC-compliant hostname.