### PR TITLE
1458674: Update use of result data to match the new async api

### DIFF
--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -101,30 +101,29 @@ class TestSubscriptionManager(TestBase):
         self.sm.check_report_state(report)
         self.assertEqual(report.state, AbstractVirtReport.STATE_PROCESSING)
 
-        def host_guest(host, guests):
+        def host(host):
             return {
-                'uuid': host,
-                'guestIds': [{'guestId': guest} for guest in guests]
+                'uuid': host
             }
         rhsmconnection.return_value.getJob.return_value = {
             'state': 'FINISHED',
             'resultData': {
                 'failedUpdate': ["failed"],
                 'updated': [
-                    host_guest('123', ['111', '222'])
+                    host('123')
                 ],
                 'created': [
-                    host_guest('456', ['333', '444'])
+                    host('456')
                 ],
                 'unchanged': [
-                    host_guest('789', ['555', '666'])
+                    host('789')
                 ]
             }
         }
         self.sm.logger = MagicMock()
         self.sm.check_report_state(report)
-        # calls: authenticating + checking job status + 3 host guest lines
-        self.assertEqual(self.sm.logger.debug.call_count, 5)
+        # calls: authenticating + checking job status + 1 line about the number of unchanged
+        self.assertEqual(self.sm.logger.debug.call_count, 3)
         self.assertEqual(report.state, AbstractVirtReport.STATE_FINISHED)
 
 

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -283,16 +283,6 @@ class SubscriptionManager(Manager):
                 return
             for fail in result_data.get('failedUpdate', []):
                 self.logger.error("Error during update list of guests: %s", str(fail))
-            for updated in result_data.get('updated', []):
-                guests = [x['guestId'] for x in updated['guestIds']]
-                self.logger.debug("Updated host %s with guests: [%s]",
-                                  updated['uuid'],
-                                  ", ".join(guests))
-            for created in result_data.get('created', []):
-                guests = [x['guestId'] for x in created['guestIds']]
-                self.logger.debug("Created host: %s with guests: [%s]",
-                                  created['uuid'],
-                                  ", ".join(guests))
             self.logger.debug("Number of mappings unchanged: %d", len(result_data.get('unchanged', [])))
             self.logger.info("Mapping for config \"%s\" updated", report.config.name)
 


### PR DESCRIPTION
We need to remove the use of the 'guestIds' attribute to match the update to CP 2.0 found here (https://github.com/candlepin/candlepin/pull/1517).

The use of the 'guestIds' attribute goes back a ways in virt-who, this will need to be fixed there as well.