### PR TITLE
1401420: xen supports only uuid/hostname as hypervisor_id

### DIFF
--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -123,13 +123,11 @@ class Xen(virt.Virt):
 
             if self.config.hypervisor_id == 'uuid':
                 uuid = record["uuid"]
-            elif self.config.hypervisor_id == 'hwuuid':
-                uuid = record["cpu_info"]['features']
             elif self.config.hypervisor_id == 'hostname':
                 uuid = record["hostname"]
             else:
                 raise virt.VirtError(
-                    'Invalid option %s for hypervisor_id, use one of: uuid, hwuuid, or hostname' %
+                    'Invalid option %s for hypervisor_id, use one of: uuid or hostname' %
                     self.config.hypervisor_id)
 
             mapping['hypervisors'].append(


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1401420
* Manual pages already contains this information:
  "hwuuid is applicable to esx and rhevm only."
* This bug is caused probably by copy pasting code from esx/rhevm.