### PR TITLE
Add VWEffectiveConfig

### DIFF
--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -64,9 +64,8 @@ class TestBase(TestCase):
         virt-who process (or None if `background` is True) and stdout is
         stdout from the process (or None if `grab_stdout` is False).
         '''
-        oldMinimumSendInterval = virtwho.executor.MinimumSendInterval
-        virtwho.executor.MinimumSendInterval = 2
-        virtwho.parser.MinimumSendInterval = 2
+        oldMinimumSendInterval = virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval']
+        virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval'] = "2"
         virtwho.log.Logger._stream_handler = None
         virtwho.log.Logger._queue_logger = None
         old_stdout = None
@@ -90,8 +89,8 @@ class TestBase(TestCase):
             sys.stdout.close()
             sys.stdout = old_stdout
 
-        virtwho.executor.MinimumSendInterval = oldMinimumSendInterval
-        virtwho.parser.MinimumSendInterval = oldMinimumSendInterval
+        virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval'] = oldMinimumSendInterval
+
         return code, data
 
     def stop_virtwho(self):

--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -64,8 +64,8 @@ class TestBase(TestCase):
         virt-who process (or None if `background` is True) and stdout is
         stdout from the process (or None if `grab_stdout` is False).
         '''
-        oldMinimumSendInterval = virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval']
-        virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval'] = "2"
+        old_minimum_send_interval = virtwho.config.MinimumSendInterval
+        virtwho.config.MinimumSendInterval = 2
         virtwho.log.Logger._stream_handler = None
         virtwho.log.Logger._queue_logger = None
         old_stdout = None
@@ -89,7 +89,7 @@ class TestBase(TestCase):
             sys.stdout.close()
             sys.stdout = old_stdout
 
-        virtwho.config.DEFAULTS[virtwho.config.VW_GLOBAL]['interval'] = oldMinimumSendInterval
+        virtwho.config.MinimumSendInterval = old_minimum_send_interval
 
         return code, data
 

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,0 +1,31 @@
+"""
+Module including Stubs of various objects for use during testing
+
+Copyright (C) 2017 Christopher Snyder <csnyder@redhat.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+
+
+class StubEffectiveConfig(object):
+
+    def __init__(self, values):
+        self.values = values
+
+    def get(self, section, option):
+        return self.values[section][option]
+
+    def getboolean(self, section, option):
+        return self.get(section, option)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -25,6 +25,8 @@ from base import TestBase
 
 from virtwho import log
 
+from stubs import StubEffectiveConfig
+
 
 class TestLog(TestBase):
     def setUp(self):
@@ -56,13 +58,17 @@ class TestLog(TestBase):
         queueLogger.logger.handlers = []
         mockQueueLogger = Mock(wraps=queueLogger)
         getQueueLogger.return_value = mockQueueLogger
-        options = Mock()
-        options.debug = False
-        options.background = True
-        options.log_file = log.DEFAULT_LOG_FILE
-        options.log_dir = log.DEFAULT_LOG_DIR
-        options.log_per_config = False
-        log.init(options)
+        conf_values = {
+            'global': {
+                'debug': False,
+                'background': True,
+                'log_file': log.DEFAULT_LOG_FILE,
+                'log_dir': log.DEFAULT_LOG_DIR,
+                'log_per_config': False
+            }
+        }
+        config = StubEffectiveConfig(conf_values)
+        log.init(config)
         main_logger = log.getLogger(name='main')
         self.assertTrue(main_logger.name == 'virtwho.main')
         self.assertTrue(len(main_logger.handlers) == 1)
@@ -116,14 +122,13 @@ class TestLog(TestBase):
 
         # Ensure we don't try to make a directory
         isdir.return_value = True
-        options = Mock()
         filtername = 'test'
-        options.log_file = 'test.log'
-        options.log_dir = '/nonexistant/'
+        log_file = 'test.log'
+        log_dir = '/nonexistant/'
 
-        log.Logger.initialize(options)
+        log.Logger.initialize(log_file=log_file, log_dir=log_dir)
         fileHandler = log.Logger.get_file_handler(filtername)
-        self.assertEquals(fileHandler.baseFilename, options.log_dir + options.log_file)
+        self.assertEquals(fileHandler.baseFilename, log_dir + log_file)
 
 
 class TestQueueLogger(TestBase):

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -325,7 +325,7 @@ class TestSatelliteConfig(TestBase):
         sys.argv = ["virt-who"]
         logger, options = parse_options()
         env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))
@@ -339,7 +339,7 @@ class TestSatelliteConfig(TestBase):
                     "--libvirt"]
         logger, options = parse_options()
         env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -31,7 +31,7 @@ from mock import MagicMock, patch
 
 from base import TestBase
 
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VIRTWHO_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.satellite import Satellite, SatelliteError
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport
@@ -324,7 +324,9 @@ class TestSatelliteConfig(TestBase):
         }
         sys.argv = ["virt-who"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
+        print env_cli_section
+        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))
@@ -337,7 +339,8 @@ class TestSatelliteConfig(TestBase):
                     "--satellite-password=password",
                     "--libvirt"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
+        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -325,7 +325,6 @@ class TestSatelliteConfig(TestBase):
         sys.argv = ["virt-who"]
         logger, options = parse_options()
         env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-        print env_cli_section
         config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -7,7 +7,7 @@ from mock import patch, Mock, DEFAULT, MagicMock, ANY
 
 from base import TestBase, unittest
 
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VIRTWHO_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.subscriptionmanager import SubscriptionManager
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport, DomainListReport, AbstractVirtReport
@@ -135,7 +135,8 @@ class TestSubscriptionManagerConfig(TestBase):
         }
         sys.argv = ["virt-who"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
+        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))
@@ -144,7 +145,8 @@ class TestSubscriptionManagerConfig(TestBase):
         os.environ = {}
         sys.argv = ["virt-who", "--sam", "--libvirt"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
+        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -136,7 +136,7 @@ class TestSubscriptionManagerConfig(TestBase):
         sys.argv = ["virt-who"]
         logger, options = parse_options()
         env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))
@@ -146,7 +146,7 @@ class TestSubscriptionManagerConfig(TestBase):
         sys.argv = ["virt-who", "--sam", "--libvirt"]
         logger, options = parse_options()
         env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-        config = Config("env/cmdline", env_cli_section['virtType'], defaults={}, **env_cli_section)
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -4,11 +4,12 @@ import tempfile
 import shutil
 
 from base import TestBase
+from stubs import StubEffectiveConfig
 
 from mock import Mock, patch, call
 from threading import Event
 
-from virtwho.config import ConfigManager, Config
+from virtwho.config import ConfigManager, Config, VW_GLOBAL
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
     DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
@@ -91,6 +92,15 @@ env=env
 
 
 class TestDestinationThread(TestBase):
+
+    def setUp(self):
+        self.options_values = {
+            VW_GLOBAL: {
+                'print_': False,
+            },
+        }
+        self.options = StubEffectiveConfig(self.options_values)
+
     def test_get_data(self):
         # Show that get_data accesses the given source and tries to retrieve
         # the right source_keys
@@ -105,15 +115,13 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread.is_initial_run = False
         result_data = destination_thread._get_data()
         self.assertEquals(result_data, datastore)
@@ -139,8 +147,6 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
@@ -148,7 +154,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=True,
-                                               options=options)
+                                               options=self.options)
         destination_thread.is_initial_run = False
         destination_thread.last_report_for_source = last_report_for_source
         result_data = destination_thread._get_data()
@@ -172,8 +178,6 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
@@ -181,7 +185,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=True,
-                                               options=options)
+                                               options=self.options)
         destination_thread._send_data(mock_error_report)
         mock_event.set.assert_called()
 
@@ -219,8 +223,6 @@ class TestDestinationThread(TestBase):
         report2.hash = "report2_hash"
         datastore = {'source1': report1, 'source2': report2}
         manager = Mock()
-        options = Mock()
-        options.print_ = False
 
         def check_hypervisorCheckIn(report, options=None):
             self.assertEquals(report.association['hypervisors'],
@@ -237,7 +239,7 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread._send_data(data_to_send)
 
     def test_send_data_poll_hypervisor_async_result(self):
@@ -293,15 +295,13 @@ class TestDestinationThread(TestBase):
         config.polling_interval = 10
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         # In this test we want to see that the wait method is called when we
         # expect and with what parameters we expect
         destination_thread.wait = Mock()
@@ -367,15 +367,13 @@ class TestDestinationThread(TestBase):
         logger = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -404,15 +402,13 @@ class TestDestinationThread(TestBase):
         manager = Mock()
         terminate_event = Mock()
         interval = 10
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -445,15 +441,13 @@ class TestDestinationThread(TestBase):
         manager.sendVirtGuests = Mock(side_effect=[error_to_throw, report1])
         terminate_event = Mock()
         interval = 10
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -470,8 +464,6 @@ class TestDestinationThread(TestBase):
         source_keys = ['source1', 'source2']
         interval = 1
         terminate_event = Mock()
-        options = Mock()
-        options.print_ = False
         config1 = Config('source1', 'esx')
         virt1 = Mock()
         virt1.CONFIG_TYPE = 'esx'
@@ -500,7 +492,7 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.is_initial_run = False
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send=data_to_send)

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -26,7 +26,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VW_GLOBAL, VIRTWHO_ENV_CLI_SECTION_NAME
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,
@@ -60,11 +60,11 @@ class TestOptions(TestBase):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py"]
         _, options = parse_options()
-        self.assertFalse(options.debug)
-        self.assertFalse(options.background)
-        self.assertFalse(options.oneshot)
-        self.assertEqual(options.interval, 3600)
-        self.assertEqual(options.smType, 'sam')
+        self.assertFalse(options.getboolean(VW_GLOBAL, 'debug'))
+        self.assertFalse(options.getboolean(VW_GLOBAL, 'background'))
+        self.assertFalse(options.getboolean(VW_GLOBAL, 'oneshot'))
+        self.assertEqual(options.getint(VW_GLOBAL,'interval'), 3600)
+        self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'smType'), 'sam')
         self.assertEqual(options.virtType, None)
         self.assertEqual(options.reporter_id, util.generateReporterId())
 

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -115,8 +115,8 @@ class TestOptions(TestBase):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--libvirt-username=admin", "--libvirt"]
         _, options = parse_options()
-        self.assertEqual(options.virtType, "libvirt")
-        self.assertEqual(options.username, "admin")
+        self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'virttype'), "libvirt")
+        self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'username'), "admin")
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.config.parseFile')
@@ -176,12 +176,12 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, 'owner')
-            self.assertEqual(options.env, 'env')
-            self.assertEqual(options.server, 'localhost')
-            self.assertEqual(options.username, 'username')
-            self.assertEqual(options.password, 'password')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'virttype'), virt)
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'owner'), 'owner')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'env'), 'env')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'server'), 'localhost')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'username'), 'username')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'password'), 'password')
 
             sys.argv = ["virtwho.py"]
             virt_up = virt.upper()
@@ -192,12 +192,12 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, 'xowner')
-            self.assertEqual(options.env, 'xenv')
-            self.assertEqual(options.server, 'xlocalhost')
-            self.assertEqual(options.username, 'xusername')
-            self.assertEqual(options.password, 'xpassword')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'virttype'), virt)
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'owner'), 'xowner')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'env'), 'xenv')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'server'), 'xlocalhost')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'username'), 'xusername')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'password'), 'xpassword')
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.config.parseFile')
@@ -215,12 +215,10 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, '')
-            self.assertEqual(options.env, '')
-            self.assertEqual(options.server, 'localhost')
-            self.assertEqual(options.username, 'username')
-            self.assertEqual(options.password, 'password')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'virttype'), virt)
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'server'), 'localhost')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'username'), 'username')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'password'), 'password')
 
             sys.argv = ["virtwho.py"]
             virt_up = virt.upper()
@@ -229,16 +227,18 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_SATELLITE_USERNAME"] = "xusername"
             os.environ["VIRTWHO_SATELLITE_PASSWORD"] = "xpassword"
             os.environ["VIRTWHO_%s" % virt_up] = "1"
+            os.environ["VIRTWHO_%s_OWNER" % virt_up] = 'xowner'
+            os.environ["VIRTWHO_%s_ENV" % virt_up] = 'xenv'
             os.environ["VIRTWHO_%s_SERVER" % virt_up] = "xlocalhost"
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, '')
-            self.assertEqual(options.env, '')
-            self.assertEqual(options.server, 'xlocalhost')
-            self.assertEqual(options.username, 'xusername')
-            self.assertEqual(options.password, 'xpassword')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'virttype'), virt)
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'server'), 'xlocalhost')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'owner'), 'xowner')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'env'), 'xenv')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'username'), 'xusername')
+            self.assertEqual(options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'password'), 'xpassword')
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.config.parseFile')

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
 from ConfigParser import SafeConfigParser, NoOptionError, Error, MissingSectionHeaderError
-from virtwho import DefaultInterval, MinimumSendInterval, log
+from virtwho import log
 from password import Password
 from binascii import unhexlify
 import hashlib
@@ -36,6 +36,10 @@ VIRTWHO_GENERAL_CONF_PATH = "/etc/virt-who.conf"
 VW_GLOBAL = "global"
 VIRTWHO_VIRT_DEFAULTS_SECTION_NAME = "defaults"
 VIRTWHO_ENV_CLI_SECTION_NAME = "env/cmdline"
+
+# Default interval for sending list of UUIDs
+DefaultInterval = 3600  # One per hour
+MinimumSendInterval = 60  # One minute
 
 
 class InvalidOption(Error):
@@ -1018,6 +1022,7 @@ def validate_global_section(configuration):
 
     if configuration.getboolean(VW_GLOBAL, "print_"):
         configuration.set(VW_GLOBAL, "oneshot", "true")
+        configuration.set_parsed(VW_GLOBAL, "oneshot", True)
 
     return log_messages
 

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -865,7 +865,10 @@ class VWEffectiveConfig(StripQuotesConfigParser):
             value = str(value)
             if param in DEFAULTS[VW_GLOBAL] and value != DEFAULTS[VW_GLOBAL][param]:
                 global_parameters[param] = value
-            elif param in section_defaults and value != section_defaults[param]:
+            elif (param in section_defaults and value != section_defaults[param]) or param not in\
+                    section_defaults:
+                # Take all parameters and their values for those params that are non-default or
+                # for which a default is unknown
                 non_global_parameters[param] = value
         return global_parameters, non_global_parameters
 
@@ -885,7 +888,7 @@ class VWEffectiveConfig(StripQuotesConfigParser):
             non_conf_files = all_dir_content - conf_files
         except OSError:
             logger.warn("Configuration directory '%s' doesn't exist or is not accessible", VW_CONF_DIR)
-            return
+            return {}
 
         if not all_dir_content:
             logger.warn("Configuration directory '%s' appears empty", VW_CONF_DIR)

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -703,11 +703,11 @@ def parseFile(filename):
 # String representations of all the default configuration for virt-who
 DEFAULTS = {
     VW_GLOBAL: {
-        'debug': "False",
-        'oneshot': "False",
-        'print_': "False",
-        'log_per_config': "False",
-        'background': "False",
+        'debug': "0",
+        'oneshot': "0",
+        'print_': "0",
+        'log_per_config': "0",
+        'background': "0",
         'configs': '',
         'reporter_id': util.generateReporterId(),
         'interval': str(DefaultInterval),
@@ -819,14 +819,10 @@ class VWEffectiveConfig(StripQuotesConfigParser):
         self._sections[VW_GLOBAL].update(**env_globals)
         self._sections[VW_GLOBAL].update(**cli_globals)
 
-        errors = validate_global_section(self)
+        self.validation_errors = validate_global_section(self)
 
         log.init(self)
         logger = log.getLogger('config', queue=False)
-
-        for log_method, message in errors:
-            if getattr(logger, log_method):
-                getattr(logger, log_method)(message)
 
         self._sections[VIRTWHO_ENV_CLI_SECTION_NAME].update(**env_non_globals)
         self._sections[VIRTWHO_ENV_CLI_SECTION_NAME].update(**cli_non_globals)
@@ -853,12 +849,12 @@ class VWEffectiveConfig(StripQuotesConfigParser):
     @staticmethod
     def filter_parameters(section, parameters):
         """
-        @param section: The name of the section to check against for defaults
-        @type section: str
-        @param parameters: A dictionary of param_name: value
-        @type parameters: dict
+        :param section: The name of the section to check against for defaults
+        :type section: str
+        :param parameters: A dictionary of param_name: value
+        :type parameters: dict
 
-        @return: Two dictionaries the first all parameters that are global in nature. The second 
+        :return: Two dictionaries the first all parameters that are global in nature. The second 
         dictionary is all non_global parameters. NOTE: Any parameter that matches a known default
         will be excluded.
         """
@@ -879,7 +875,7 @@ class VWEffectiveConfig(StripQuotesConfigParser):
     def all_drop_dir_config_sections():
         """
         Read all configuration sections in the default config directory
-        @return: a dictionary of {section_name: {key: value, ... } ... }
+        :return: a dictionary of {section_name: {key: value, ... } ... }
         """
         parser = StripQuotesConfigParser()
         all_dir_content = None
@@ -931,7 +927,8 @@ class VWEffectiveConfig(StripQuotesConfigParser):
 
 def validate_global_section(configuration):
     """
-    Validates the global section from the effective configuration. Ensures the values defined there 
+    :param configuration: The Effective Configuration object whose global section needs validation
+    Validates the global section from the effective configuration. Ensures the values defined there
     are correct.
     """
     log_messages = []

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -1,20 +1,13 @@
 import time
 from threading import Event
-from Queue import Empty, Queue
-import errno
-import socket
 import sys
 
-from virtwho import log, MinimumSendInterval
+from virtwho import log
 
 from virtwho.config import ConfigManager, VW_GLOBAL
 from virtwho.datastore import Datastore
-from virtwho.manager import (
-    Manager, ManagerThrottleError, ManagerError, ManagerFatalError)
-from virtwho.virt import (
-    AbstractVirtReport, ErrorReport, DomainListReport,
-    HostGuestAssociationReport, Virt, DestinationThread,
-    info_to_destination_class)
+from virtwho.manager import Manager
+from virtwho.virt import Virt, info_to_destination_class
 
 try:
     from collections import OrderedDict

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -7,7 +7,7 @@ import sys
 
 from virtwho import log, MinimumSendInterval
 
-from virtwho.config import ConfigManager
+from virtwho.config import ConfigManager, VW_GLOBAL
 from virtwho.datastore import Datastore
 from virtwho.manager import (
     Manager, ManagerThrottleError, ManagerError, ManagerFatalError)
@@ -61,8 +61,8 @@ class Executor(object):
                 logger = log.getLogger(config=config)
                 virt = Virt.from_config(logger, config, self.datastore,
                                         terminate_event=self.terminate_event,
-                                        interval=self.options.interval,
-                                        oneshot=self.options.oneshot)
+                                        interval=self.options.get(VW_GLOBAL, 'interval'),
+                                        oneshot=self.options.get(VW_GLOBAL, 'oneshot'))
             except Exception as e:
                 self.logger.error('Unable to use configuration "%s": %s', config.name, str(e))
                 continue
@@ -91,8 +91,8 @@ class Executor(object):
                               options=self.options,
                               source=self.datastore, dest=manager,
                               terminate_event=self.terminate_event,
-                              interval=self.options.interval,
-                              oneshot=self.options.oneshot)
+                              interval=self.options.get(VW_GLOBAL, 'interval'),
+                              oneshot=self.options.get(VW_GLOBAL, 'oneshot'))
             dests.append(dest)
         return dests
 
@@ -165,7 +165,7 @@ class Executor(object):
 
         Executor.wait_on_threads(self.virts)
 
-        if self.options.print_:
+        if self.options.get(VW_GLOBAL, 'print_'):
             to_print = {}
             for source in self.configManager.sources:
                 try:
@@ -183,7 +183,8 @@ class Executor(object):
         Executor.wait_on_threads(self.destinations)
 
     def run(self):
-        self.logger.debug("Starting infinite loop with %d seconds interval", self.options.interval)
+        self.logger.debug("Starting infinite loop with %d seconds interval",
+                          self.options.get(VW_GLOBAL,'interval'))
 
         # Need to update the dest to source mapping of the configManager object
         # here because of the way that main reads the config from the command

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -174,18 +174,18 @@ class Logger(object):
     _background = False
 
     @classmethod
-    def initialize(cls, options):
+    def initialize(cls, config):
         # Set defaults if necessary
-        if options.log_dir:
-            cls._log_dir = options.log_dir
-        if options.log_file:
-            cls._log_file = options.log_file
-        if options.log_per_config:
+        if config.get('global', 'log_dir'):
+            cls._log_dir = config.get('global', 'log_dir')
+        if config.get('global', 'log_file'):
+            cls._log_file = config.get('global', 'log_file')
+        if config.getboolean('global', 'log_per_config'):
             cls._log_per_config = True
-        cls._level = logging.DEBUG if options.debug else logging.INFO
+        cls._level = logging.DEBUG if config.getboolean('global', 'debug') else logging.INFO
         # We don't want INFO message from RHSM in non-debug mode
-        cls._rhsm_level = logging.DEBUG if options.debug else logging.WARN
-        cls._background = options.background
+        cls._rhsm_level = logging.DEBUG if config.getboolean('global', 'debug') else logging.WARN
+        cls._background = config.getboolean('global', 'background')
 
     @classmethod
     def get_logger(cls, name=None, config=None, queue=True):

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -174,18 +174,19 @@ class Logger(object):
     _background = False
 
     @classmethod
-    def initialize(cls, config):
+    def initialize(cls, log_dir=None, log_file=None, log_per_config=None,
+                   debug=None, background=None):
         # Set defaults if necessary
-        if config.get('global', 'log_dir'):
-            cls._log_dir = config.get('global', 'log_dir')
-        if config.get('global', 'log_file'):
-            cls._log_file = config.get('global', 'log_file')
-        if config.getboolean('global', 'log_per_config'):
+        if log_dir:
+            cls._log_dir = log_dir
+        if log_file:
+            cls._log_file = log_file
+        if log_per_config:
             cls._log_per_config = True
-        cls._level = logging.DEBUG if config.getboolean('global', 'debug') else logging.INFO
+        cls._level = logging.DEBUG if debug else logging.INFO
         # We don't want INFO message from RHSM in non-debug mode
-        cls._rhsm_level = logging.DEBUG if config.getboolean('global', 'debug') else logging.WARN
-        cls._background = config.getboolean('global', 'background')
+        cls._rhsm_level = logging.DEBUG if debug else logging.WARN
+        cls._background = bool(background)
 
     @classmethod
     def get_logger(cls, name=None, config=None, queue=True):
@@ -299,8 +300,14 @@ class Logger(object):
         return cls._queue_logger is not None
 
 
-def init(options):
-    return Logger.initialize(options)
+def init(config):
+    log_dir = config.get('global', 'log_dir')
+    log_file = config.get('global', 'log_file')
+    log_per_config = config.get('global', 'log_per_config')
+    debug = config.getboolean('global', 'debug')
+    background = config.getboolean('global', 'background')
+    return Logger.initialize(log_dir=log_dir, log_file=log_file, log_per_config=log_per_config,
+                             debug=debug, background=background)
 
 
 def getLogger(name=None, config=None, queue=True):

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -34,7 +34,6 @@ from virtwho import log
 from virtwho.config import Config, InvalidPasswordFormat, InvalidOption, VW_GLOBAL, VIRTWHO_ENV_CLI_SECTION_NAME
 from virtwho.daemon import daemon
 from virtwho.executor import Executor, ReloadRequest
-from virtwho.manager import ManagerFatalError
 from virtwho.parser import parse_options, OptionError
 from virtwho.password import InvalidKeyFile
 from virtwho.virt import DomainListReport, HostGuestAssociationReport

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -131,8 +131,8 @@ def main():
         exit(1, "virt-who can't be started: %s" % str(e))
     # Attempting to create a "Config" object from the global section
     env_cli_section = options.get_section(VIRTWHO_ENV_CLI_SECTION_NAME)
-    if env_cli_section.get('virtType') is not None:
-        config = Config("env/cmdline", env_cli_section['virtType'],
+    if env_cli_section.get('virttype') is not None:
+        config = Config("env/cmdline", env_cli_section['virttype'],
                         executor.configManager._defaults, **env_cli_section)
         try:
             config.checkOptions(logger)

--- a/virtwho/manager/manager.py
+++ b/virtwho/manager/manager.py
@@ -18,6 +18,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
+from virtwho.config import VIRTWHO_ENV_CLI_SECTION_NAME
 
 class ManagerError(Exception):
     pass
@@ -70,7 +71,7 @@ class Manager(object):
         assert virtwho
 
         config_smType = config.smType if config else None
-        smType = config_smType or options['smType'] or 'sam'
+        smType = config_smType or options.get(VIRTWHO_ENV_CLI_SECTION_NAME, 'smType') or 'sam'
 
         for subcls in cls.__subclasses__():
             if subcls.smType == smType:

--- a/virtwho/manager/manager.py
+++ b/virtwho/manager/manager.py
@@ -70,7 +70,7 @@ class Manager(object):
         assert virtwho
 
         config_smType = config.smType if config else None
-        smType = config_smType or options.smType or 'sam'
+        smType = config_smType or options['smType'] or 'sam'
 
         for subcls in cls.__subclasses__():
             if subcls.smType == smType:

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -24,8 +24,8 @@ configuration from environment variables.
 import os
 from argparse import ArgumentParser, Action
 
-from virtwho import log, MinimumSendInterval, DefaultInterval
-from virtwho.config import GlobalConfig, NotSetSentinel, VWEffectiveConfig, DEFAULTS, VW_GLOBAL
+from virtwho import log
+from virtwho.config import NotSetSentinel, VWEffectiveConfig, DEFAULTS, VW_GLOBAL
 from virtwho.virt.virt import Virt
 
 

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -629,9 +629,4 @@ class EnvParser(object):
         if sm_type is not None:
             parsed['smType'] = sm_type
 
-        # print "--------PARSED VALUES------------"
-        # for key, value in parsed.iteritems():
-        #     print "%s: %s" % (key, value)
-        #
-        # print "-------END OF PARSED VALUES------"
         return parsed

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -25,7 +25,8 @@ import os
 from argparse import ArgumentParser, Action
 
 from virtwho import log
-from virtwho.config import NotSetSentinel, VWEffectiveConfig, DEFAULTS, VW_GLOBAL
+from virtwho.config import NotSetSentinel, VWEffectiveConfig, DEFAULTS, VW_GLOBAL,\
+    VIRTWHO_ENV_CLI_SECTION_NAME
 from virtwho.virt.virt import Virt
 
 
@@ -141,6 +142,11 @@ def check_argument_consistency(cli_options):
     elif sm_type is None:
         errors.append(('warning', 'Unable to check cli argument consistency, no destination '
                                   'provided'))
+        return errors
+    else:
+        errors.append(('warning', 'Unable to check cli argument consistency, no known destination '
+                                  'provided'))
+        return errors
 
     if virt_type is not None:
         for option in REQUIRED_OPTIONS:
@@ -229,7 +235,6 @@ def read_config_env_variables():
     #     env_vars.log_dir = env
     # elif env_vars.log_per_config:
     #     env_vars.log_dir = os.path.join(log.DEFAULT_LOG_DIR, 'virtwho')
-
     return env_vars
 
 
@@ -254,7 +259,7 @@ def read_vm_backend_env_variables(env_vars):
     """
     errors = []
 
-    sm_type = env_vars.get('smType')
+    sm_type = env_vars.get('smType', DEFAULTS[VIRTWHO_ENV_CLI_SECTION_NAME]['smtype'])
     if sm_type is None:
         # Just don't read the env vars if there is no smType specified
         return env_vars, errors
@@ -290,7 +295,6 @@ def read_vm_backend_env_variables(env_vars):
         except OptionError as err:
             errors.append(("error", "Error: reading environment variables for virt. type: %s: %s" % (
                 env_vars.get('virtType'), err)))
-            env_vars['virtType'] = None
         else:
             if len(env_vars.get('password', '')) == 0:
                 env_vars['password'] = os.getenv("VIRTWHO_" + virt_type.upper() + "_PASSWORD", "")
@@ -338,7 +342,7 @@ def parse_cli_arguments():
         description="Choose virtualization backend that should be used to gather host/guest associations"
     )
     virt_group.add_argument("--libvirt", action=StoreVirtType, dest="virtType", const="libvirt",
-                            default=None, help="Use libvirt to list virtual guests")
+                            help="Use libvirt to list virtual guests")
     virt_group.add_argument("--vdsm", action=StoreVirtType, dest="virtType", const="vdsm",
                             help="Use vdsm to list virtual guests")
     virt_group.add_argument("--esx", action=StoreVirtType, dest="virtType", const="esx",

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -25,7 +25,7 @@ import os
 from argparse import ArgumentParser, Action
 
 from virtwho import log, MinimumSendInterval, DefaultInterval
-from virtwho.config import GlobalConfig, NotSetSentinel, VIRTWHO_GENERAL_CONF_PATH, VWEffectiveConfig
+from virtwho.config import GlobalConfig, NotSetSentinel, VWEffectiveConfig, DEFAULTS, VW_GLOBAL
 from virtwho.virt.virt import Virt
 
 
@@ -131,8 +131,8 @@ def check_argument_consistency(cli_options):
     # These options can be required
     REQUIRED_OPTIONS = ['owner', 'env', 'server', 'username']
 
-    virt_type = cli_options['virtType']
-    sm_type = cli_options['smType']
+    virt_type = cli_options.get('virtType')
+    sm_type = cli_options.get('smType')
 
     if sm_type == 'sam':
         VM_DISPATCHER = SAM_VM_DISPATCHER
@@ -153,35 +153,46 @@ def check_argument_consistency(cli_options):
                     raise OptionError("Argument --%s cannot be set without virtualization backend" % key)
 
 
-def read_config_env_variables(options):
+def read_config_env_variables():
     """
-    This function tries to load environment variables and it save them
-    to options.
-    :param options: Dictionary with options of virt-who
-    :return: List of errors for further logging, because logger is not
-    available in this scope.
+    This function tries to load environment variables and it will add them to a dictionary
+    returned.
+    :return: the dictonary of configuration values -> parsed value
     """
 
-    errors = []
+    # The dictionary to return
+    env_vars = {}
 
     # Function called by dispatcher
     def store_const(_options, _attr, _env, _const):
         if _env.lower() in ["1", "true"]:
-            setattr(_options, _attr, _const)
+            _options[_attr] = _const
 
     # Function called by dispatcher
     def store_value(_options, _attr, _env, _def_value):
-        if _env != _def_value:
-            setattr(_options, _attr, _env)
+        if _env is not None and _env != _def_value and _env != "":
+            _options[_attr] = _env
 
-    # Dispatcher for storing environment values in options object
+    # Dispatcher for storing environment values in env_vars object
     dispatcher = {
         # environment variable: (attribute_name, default_value, method, const)
-        "VIRTWHO_LOG_PER_CONFIG": ("log_per_config", "0", store_const, True),
-        "VIRTWHO_LOG_FILE": ("log_file", log.DEFAULT_LOG_FILE, store_value),
-        "VIRTWHO_DEBUG": ("debug", "0", store_const, True),
-        "VIRTWHO_BACKGROUND": ("background", "0", store_const, True),
-        "VIRTWHO_ONE_SHOT": ("oneshot", "0", store_const, True),
+        "VIRTWHO_LOG_PER_CONFIG": ("log_per_config",
+                                   DEFAULTS[VW_GLOBAL]["log_per_config"],
+                                   store_const, "true"),
+        "VIRTWHO_LOG_FILE": ("log_file",
+                             DEFAULTS[VW_GLOBAL]["log_file"],
+                             store_value),
+        "VIRTWHO_DEBUG": ("debug",
+                          DEFAULTS[VW_GLOBAL]["debug"],
+                          store_const, "true"),
+        "VIRTWHO_BACKGROUND": ("background",
+                               DEFAULTS[VW_GLOBAL]["background"],
+                               store_const,
+                               "true"),
+        "VIRTWHO_ONE_SHOT": ("oneshot",
+                             DEFAULTS[VW_GLOBAL]["oneshot"],
+                             store_const,
+                             "true"),
         "VIRTWHO_SAM": ("smType", "0", store_const, SAT6),
         "VIRTWHO_SATELLITE6": ("smType", "0", store_const, SAT6),
         "VIRTWHO_SATELLITE5": ("smType", "0", store_const, SAT5),
@@ -191,10 +202,12 @@ def read_config_env_variables(options):
         "VIRTWHO_ESX": ("virtType", "0", store_const, "esx"),
         "VIRTWHO_XEN": ("virtType", "0", store_const, "xen"),
         "VIRTWHO_RHEVM": ("virtType", "0", store_const, "rhevm"),
-        "VIRTWHO_HYPERV": ("virtType", "0", store_const, "hyperv")
+        "VIRTWHO_HYPERV": ("virtType", "0", store_const, "hyperv"),
+        "VIRTWHO_INTERVAL": ("interval", DEFAULTS[VW_GLOBAL]["interval"], store_value),
+        "VIRTWHO_REPORTER_ID": ("reporter_id", DEFAULTS[VW_GLOBAL]["reporter_id"], store_value),
     }
 
-    # Store values of environment variables to options using dispatcher
+    # Store values of environment variables to env_vars using dispatcher
     for key, values in dispatcher.items():
         attribute = values[0]
         default_value = values[1]
@@ -204,33 +217,18 @@ def read_config_env_variables(options):
         try:
             value = values[3]
         except IndexError:
-            method(options, attribute, env, default_value)
+            method(env_vars, attribute, env, default_value)
         else:
-            method(options, attribute, env, value)
+            method(env_vars, attribute, env, value)
 
-    # Some special cases is better keep out of dispatcher
-    env = os.getenv("VIRTWHO_REPORTER_ID", "").strip()
-    if len(env) > 0:
-        options.reporter_id = env
+    # Todo: move this logic to the VWEffectiveConfig
+    # env = os.getenv("VIRTWHO_LOG_DIR", log.DEFAULT_LOG_DIR).strip()
+    # if env != log.DEFAULT_LOG_DIR:
+    #     env_vars.log_dir = env
+    # elif env_vars.log_per_config:
+    #     env_vars.log_dir = os.path.join(log.DEFAULT_LOG_DIR, 'virtwho')
 
-    env = os.getenv("VIRTWHO_INTERVAL", "").strip()
-    if env:
-        try:
-            interval = int(env)
-            if interval >= MinimumSendInterval:
-                options.interval = interval
-            elif interval < MinimumSendInterval:
-                options.interval = MinimumSendInterval
-        except ValueError:
-            errors.append(("warning", "Interval: %s is not number, ignoring" % env))
-
-    env = os.getenv("VIRTWHO_LOG_DIR", log.DEFAULT_LOG_DIR).strip()
-    if env != log.DEFAULT_LOG_DIR:
-        options.log_dir = env
-    elif options.log_per_config:
-        options.log_dir = os.path.join(log.DEFAULT_LOG_DIR, 'virtwho')
-
-    return errors
+    return env_vars
 
 
 def check_env(variable, option, required=True):
@@ -245,43 +243,56 @@ def check_env(variable, option, required=True):
     return option
 
 
-def read_vm_backend_env_variables(logger, options):
+def read_vm_backend_env_variables(env_vars):
     """
     Try to read environment variables for virtual manager backend
     :param logger: Object used for logging
-    :param options: Dictionary with options
+    :param env_vars: Dictionary with env_vars
     :return: None
     """
-    if options.smType == SAT5:
-        options.sat_server = check_env("VIRTWHO_SATELLITE_SERVER", options.sat_server)
-        options.sat_username = check_env("VIRTWHO_SATELLITE_USERNAME", options.sat_username)
-        if len(options.sat_password) == 0:
-            options.sat_password = os.getenv("VIRTWHO_SATELLITE_PASSWORD", "")
+    errors = []
 
-    if options.smType == 'sam':
+    sm_type = env_vars.get('smType')
+    if sm_type is None:
+        # Just don't read the env vars if there is no smType specified
+        return env_vars, errors
+
+    if sm_type == SAT5:
+        env_vars['sat_server'] = os.getenv("VIRTWHO_SATELLITE_SERVER")
+        env_vars['sat_username'] = os.getenv("VIRTWHO_SATELLITE_USERNAME")
+        env_vars['sat_password'] = os.getenv("VIRTWHO_SATELLITE_PASSWORD")
+
+    if sm_type == SAT5:
         VM_DISPATCHER = SAM_VM_DISPATCHER
-    elif options.smType == 'satellite':
+    elif sm_type == SAT6:
         VM_DISPATCHER = SAT_VM_DISPATCHER
     else:
-        raise OptionError("Report host/guest associations was not specified.")
+        errors.append(("warning", "Env"))
+        VM_DISPATCHER = {}
 
-    if options.virtType in VM_DISPATCHER.keys():
-        virt_type = options.virtType
+    if env_vars.get('virtType') in VM_DISPATCHER.keys():
+        virt_type = env_vars['virtType']
         try:
-            options.owner = check_env("VIRTWHO_" + virt_type.upper() + "_OWNER", options.owner,
-                                      required=VM_DISPATCHER[virt_type]['owner'])
-            options.env = check_env("VIRTWHO_" + virt_type.upper() + "_ENV", options.env,
-                                    required=VM_DISPATCHER[virt_type]['env'])
-            options.server = check_env("VIRTWHO_" + virt_type.upper() + "_SERVER", options.server,
-                                       required=VM_DISPATCHER[virt_type]['server'])
-            options.username = check_env("VIRTWHO_" + virt_type.upper() + "_USERNAME", options.username,
-                                         required=VM_DISPATCHER[virt_type]['username'])
+            env_vars['owner'] = check_env("VIRTWHO_" + virt_type.upper() + "_OWNER",
+                                          env_vars.get('owner'),
+                                          required=VM_DISPATCHER[virt_type]['owner'])
+            env_vars['env'] = check_env("VIRTWHO_" + virt_type.upper() + "_ENV",
+                                        env_vars.get('env'),
+                                        required=VM_DISPATCHER[virt_type]['env'])
+            env_vars['server'] = check_env("VIRTWHO_" + virt_type.upper() + "_SERVER",
+                                           env_vars.get('server'),
+                                           required=VM_DISPATCHER[virt_type]['server'])
+            env_vars['username'] = check_env("VIRTWHO_" + virt_type.upper() + "_USERNAME",
+                                             env_vars.get('username'),
+                                             required=VM_DISPATCHER[virt_type]['username'])
         except OptionError as err:
-            logger.error("Error: reading environment variables for virt. type: %s: %s" % (options.virtType, err))
-            options.virtType = None
+            errors.append(("error", "Error: reading environment variables for virt. type: %s: %s" % (
+                env_vars.get('virtType'), err)))
+            env_vars['virtType'] = None
         else:
-            if len(options.password) == 0:
-                options.password = os.getenv("VIRTWHO_" + virt_type.upper() + "_PASSWORD", "")
+            if len(env_vars.get('password', '')) == 0:
+                env_vars['password'] = os.getenv("VIRTWHO_" + virt_type.upper() + "_PASSWORD", "")
+    return env_vars, errors
 
 
 def parse_cli_arguments():
@@ -448,7 +459,11 @@ def parse_cli_arguments():
     # Get all default options
     defaults = vars(parser.parse_args([]))
 
-    return cli_options, defaults
+    def get_non_default_options(_cli_options, _defaults):
+        return dict((option, value) for option, value in _cli_options.iteritems()
+                    if _defaults.get(option, NotSetSentinel()) != value and value is not None)
+
+    return get_non_default_options(cli_options, defaults)
 
 
 def parse_options():
@@ -458,20 +473,19 @@ def parse_options():
     """
 
     # Read command line arguments first
-    cli_options, defaults = parse_cli_arguments()
-
-    # Read option from global config file
-    options = GlobalConfig.fromFile(VIRTWHO_GENERAL_CONF_PATH)
-
-    # Handle defaults from the command line options parser
-    options.update(**cli_options)
+    cli_options = parse_cli_arguments()
 
     # Read configuration env. variables
-    errors = read_config_env_variables(options)
+    env_options = read_config_env_variables()
 
-    # It is possible to initialize logger now
-    log.init(options)
-    logger = log.getLogger(name='init', queue=False)
+    # Read environments variables for virtualization backends
+    env_options, errors = read_vm_backend_env_variables(env_options)
+    # Create the effective config that virt-who will use to run
+    effective_config = VWEffectiveConfig(env_options, cli_options)
+    # Ensure validation errors during effective config creation are logged
+    errors.extend(effective_config.validation_errors)
+
+    logger = log.getLogger("init", queue=False)
 
     # Log pending errors
     for err in errors:
@@ -479,28 +493,7 @@ def parse_options():
         if method is not None:
             method(err[1])
 
-    def get_non_default_options(_cli_options, _defaults):
-        return dict((option, value) for option, value in _cli_options.iteritems()
-                    if _defaults.get(option, NotSetSentinel()) != value)
-
-    # Handle non-default command line options
-    options.update(**get_non_default_options(cli_options, defaults))
-
-    # Read environments variables for virtualization backends
-    read_vm_backend_env_variables(logger, options)
-
-    if not options.interval or options.interval == defaults['interval']:
-        logger.info("Interval set to the default of %d seconds.", DefaultInterval)
-        options.interval = DefaultInterval
-    elif options.interval < MinimumSendInterval:
-        logger.warning("Interval value can't be lower than {min} seconds. "
-                       "Default value of {min} seconds will be used.".format(min=MinimumSendInterval))
-        options.interval = MinimumSendInterval
-
-    if options.print_:
-        options.oneshot = True
-
-    return logger, options
+    return logger, effective_config
 
 
 class EnvParser(object):

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -25,7 +25,7 @@ import os
 from argparse import ArgumentParser, Action
 
 from virtwho import log, MinimumSendInterval, DefaultInterval
-from virtwho.config import GlobalConfig, NotSetSentinel, VIRTWHO_GENERAL_CONF_PATH
+from virtwho.config import GlobalConfig, NotSetSentinel, VIRTWHO_GENERAL_CONF_PATH, VWEffectiveConfig
 from virtwho.virt.virt import Virt
 
 

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -814,7 +814,7 @@ class Satellite5DestinationThread(DestinationThread):
         # Terminate this thread if we have sent one report for each source
         if all(source_key in sources_sent for source_key in self.source_keys)\
                 and self._oneshot:
-            if not self.options.print_:
+            if not self.options.get(VW_GLOBAL, 'print_'):
                 self.logger.debug('At least one report for each connected '
                                   'source has been sent. Terminating.')
             else:

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -29,7 +29,7 @@ import hashlib
 import re
 import fnmatch
 from virtwho.config import NotSetSentinel, Satellite5DestinationInfo, \
-    Satellite6DestinationInfo, DefaultDestinationInfo
+    Satellite6DestinationInfo, DefaultDestinationInfo, VW_GLOBAL
 from virtwho.manager import ManagerError, ManagerThrottleError, ManagerFatalError
 from virtwho import MinimumSendInterval
 
@@ -40,6 +40,7 @@ except ImportError:
     from virtwho.util import OrderedDict
 
 from virtwho import DefaultInterval
+
 
 class VirtError(Exception):
     pass
@@ -686,7 +687,7 @@ class DestinationThread(IntervalThread):
         # Send each Domain Guest List Report if necessary
         for source_key in domain_list_reports:
             report = data_to_send[source_key]
-            if not self.options.print_:
+            if not self.options.get(VW_GLOBAL, 'print_'):
                 retry = True
                 num_429_received = 0
                 while retry and not self.is_terminated():  # Retry if we encounter a 429
@@ -721,7 +722,7 @@ class DestinationThread(IntervalThread):
 
         # Terminate this thread if we have sent one report for each source
         if all_sources_handled and self._oneshot:
-                if not self.options.print_:
+                if not self.options.get(VW_GLOBAL, 'print_'):
                     self.logger.debug('At least one report for each connected source has been sent. Terminating.')
                 else:
                     self.logger.debug('All info to print has been gathered. Terminating.')


### PR DESCRIPTION
This PR adds a config object that will largely replace much of the remainder of config.py.
This EffectiveConfig (or VWEffectiveConfig as it is currently named), represents the total configuration that virt-who will use while running.
The new config object takes in the cli_options (parsed from the command line) and the env_options (parsed from the environement) as well as the contents of /etc/virt-who.conf as well as /etc/virt-who.d/*.conf.

This object implements the hierarchy from which the effective values for a given configuration section of virt-who are derived. In addition this object validates the global values (those values that affect virt-who as a whole).

This PR is not meant for master yet as it is the first step towards (hopefully) cleaner configuration in virt-who. That being said the tests should pass with this PR. The VWEffectiveConfig has been integrated into virt-who and is now used in place of the GlobalConfig.


Please note: I would like to squash these commits down once review (and requisite clean up) has taken place.

Also note: config.EnvParser is an alternative implementation of a parser of environment variables. It can likely be removed but I could see an argument for using that version instead.